### PR TITLE
amended post build events to ease installer creation

### DIFF
--- a/Grasshopper_UI/Grasshopper_UI.csproj
+++ b/Grasshopper_UI/Grasshopper_UI.csproj
@@ -363,9 +363,14 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\Users\$(Username)\AppData\Roaming\Grasshopper\Libraries\BHoM"
+    <PostBuildEvent>rename "$(TargetName).dll" "$(TargetName).gha"
 
-Copy /Y "$(TargetName).dll" "C:\Users\$(Username)\AppData\Roaming\Grasshopper\Libraries\BHoM\$(TargetName).gha"</PostBuildEvent>
+call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\Users\$(Username)\AppData\Roaming\Grasshopper\Libraries\BHoM"
+Copy /Y "$(TargetName).gha" "C:\Users\$(Username)\AppData\Roaming\Grasshopper\Libraries\BHoM\$(TargetName).gha"
+
+
+call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\Users\$(Username)\AppData\Roaming\BHoM\InstallFiles\Grasshopper"
+copy "$(TargetName).gha" "C:\Users\$(Username)\AppData\Roaming\BHoM\InstallFiles\Grasshopper\$(TargetName).gha" /Y</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <FallbackCulture>en-US</FallbackCulture>


### PR DESCRIPTION
Fixes #304 

When building the Grasshopper_Toolkit we are now creating a copy of the AppData\Roaming\Grasshopper\Libraries\BHoM into AppData\Roaming\BHoM\InstallFiles\Grasshopper

This is to ensure consistencies when building the installer and avoid copying and pasting flying files from who-knows-from-which-folder-to-choose