### PR TITLE
Reinstating CreateCustom functionalities- Issues 302 and 307

### DIFF
--- a/Grasshopper_Engine/Create/DataTree.cs
+++ b/Grasshopper_Engine/Create/DataTree.cs
@@ -52,5 +52,28 @@ namespace BH.Engine.Grasshopper
         }
 
         /*******************************************/
+
+        public static DataTree<T> DataTree<T>(List<IEnumerable<T>> data, int iteration, IList<GH_Path> paths)
+        {
+            DataTree<T> master = new DataTree<T>();
+            if (data.Count == 0)
+            {
+                master.EnsurePath(0);
+                return new DataTree<T>();
+            }
+            else
+            {
+                for (int i = 0; i < data.Count; i++)
+                {
+                    DataTree<T> local = new DataTree<T>(data[i], paths[i]);
+                    GH_Path path = paths[iteration].AppendElement(i);
+                    master.EnsurePath(path);
+                    master.AddRange(data[i], path);
+                }
+            }
+            return master;
+        }
+
+        /*******************************************/
     }
 }

--- a/Grasshopper_Engine/Grasshopper_Engine.csproj
+++ b/Grasshopper_Engine/Grasshopper_Engine.csproj
@@ -98,6 +98,12 @@
     <Compile Include="Convert\ToType.cs" />
     <Compile Include="Convert\ToRhino.cs" />
     <Compile Include="Create\DataTree.cs" />
+    <Compile Include="Query\AvailableHints.cs" />
+    <Compile Include="Objects\Hints\IGeometryHint.cs" />
+    <Compile Include="Objects\Hints\BHomObjectHint.cs" />
+    <Compile Include="Objects\Hints\DictionaryHint.cs" />
+    <Compile Include="Objects\Hints\EnumHint.cs" />
+    <Compile Include="Objects\Hints\TypeHint.cs" />
     <Compile Include="Objects\Types\GH_BHoMObject.cs" />
     <Compile Include="Objects\Types\GH_Dictionary.cs" />
     <Compile Include="Objects\Types\GH_Enum.cs" />

--- a/Grasshopper_Engine/Grasshopper_Engine.csproj
+++ b/Grasshopper_Engine/Grasshopper_Engine.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Query\RenderColor.cs" />
     <Compile Include="Query\RenderMaterial.cs" />
+    <Compile Include="Query\Type.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Modify\" />

--- a/Grasshopper_Engine/Objects/Hints/BHomObjectHint.cs
+++ b/Grasshopper_Engine/Objects/Hints/BHomObjectHint.cs
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using BH.Engine.Grasshopper.Objects;
+using Grasshopper.Kernel.Parameters;
+
+namespace BH.UI.Grasshopper.Objects.Hints
+{
+    public class BHoMObjectHint : IGH_TypeHint
+    {
+        /*******************************************/
+        /**** Properties                        ****/
+        /*******************************************/
+
+        public Guid HintID { get; } = new Guid("0977C35E-92DD-4933-8835-8B2C8A37C8CF"); 
+
+        public string TypeName { get; } = "BH.oM.Base.BHoMObject"; 
+
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public bool Cast(object data, out object target)
+        {
+            GH_BHoMObject obj = new GH_BHoMObject() { Value = null };
+            obj.CastFrom(data);
+            if (obj.Value == null)
+                target = data;
+            else
+                target = obj.Value;
+            return true;
+        }
+
+        /*******************************************/
+    }
+}

--- a/Grasshopper_Engine/Objects/Hints/DictionaryHint.cs
+++ b/Grasshopper_Engine/Objects/Hints/DictionaryHint.cs
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using BH.Engine.Grasshopper.Objects;
+using Grasshopper.Kernel.Parameters;
+
+namespace BH.UI.Grasshopper.Objects.Hints
+{
+    public class DictionaryHint : IGH_TypeHint
+    {
+        /*******************************************/
+        /**** Properties                        ****/
+        /*******************************************/
+
+        public Guid HintID { get; } = new Guid("1574563B-80AC-486D-B175-A4F2E5EC76D5"); 
+        public string TypeName { get; } = "Dictionary"; 
+
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public bool Cast(object data, out object target)
+        {
+            GH_Dictionary dict = new GH_Dictionary() { Value = null };
+            dict.CastFrom(data);
+            if (dict.Value == null)
+                target = data;
+            else
+                target = dict.Value;
+            return true;
+        }
+
+        /*******************************************/
+    }
+}

--- a/Grasshopper_Engine/Objects/Hints/EnumHint.cs
+++ b/Grasshopper_Engine/Objects/Hints/EnumHint.cs
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using BH.Engine.Grasshopper.Objects;
+using Grasshopper.Kernel.Parameters;
+
+namespace BH.UI.Grasshopper.Objects.Hints
+{
+    public class EnumHint : IGH_TypeHint
+    {
+        /*******************************************/
+        /**** Properties                        ****/
+        /*******************************************/
+
+        public Guid HintID { get; } = new Guid("50201E4F-F9F3-4BE5-A927-98AE2EE03530"); 
+        public string TypeName { get; } = "System.Enum"; 
+
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public bool Cast(object data, out object target)
+        {
+            GH_Enum enumer = new GH_Enum() { Value = null };
+            enumer.CastFrom(data);
+            if (enumer.Value == null)
+                target = data;
+            else
+                target = enumer.Value;
+            return true;
+        }
+
+        /*******************************************/
+    }
+}

--- a/Grasshopper_Engine/Objects/Hints/IGeometryHint.cs
+++ b/Grasshopper_Engine/Objects/Hints/IGeometryHint.cs
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using BH.Engine.Grasshopper.Objects;
+using Grasshopper.Kernel.Parameters;
+
+namespace BH.UI.Grasshopper.Objects.Hints
+{
+    public class IGeometryHint : IGH_TypeHint
+    {
+        /*******************************************/
+        /**** Properties                        ****/
+        /*******************************************/
+
+        public Guid HintID { get; } = new Guid("CC64E37E-C6B8-44F4-9C85-05B19849F4D6"); 
+
+        public string TypeName { get; } = "BH.oM.Geometry.IGeometry"; 
+
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public bool Cast(object data, out object target)
+        {
+            GH_IBHoMGeometry geom = new GH_IBHoMGeometry() { Value = null };
+            geom.CastFrom(data);
+            if (geom.Value == null)
+                target = data;
+            else
+                target = geom.Value;
+            return true;
+        }
+
+        /*******************************************/
+    }
+}

--- a/Grasshopper_Engine/Objects/Hints/TypeHint.cs
+++ b/Grasshopper_Engine/Objects/Hints/TypeHint.cs
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using BH.Engine.Grasshopper.Objects;
+using Grasshopper.Kernel.Parameters;
+
+namespace BH.UI.Grasshopper.Objects.Hints
+{
+    public class TypeHint : IGH_TypeHint
+    {
+        /*******************************************/
+        /**** Properties                        ****/
+        /*******************************************/
+
+        public Guid HintID { get; } = new Guid("8ECF16E7-F71B-4813-AD63-C4AECC246A26");
+
+        public string TypeName { get; } = "System.Type";
+
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public bool Cast(object data, out object target)
+        {
+            GH_Type type = new GH_Type() { Value = null };
+            type.CastFrom(data);
+            if (type.Value == null)
+                target = data;
+            else
+                target = type.Value;
+            return true;
+        }
+
+        /*******************************************/
+    }
+}

--- a/Grasshopper_Engine/Query/AvailableHints.cs
+++ b/Grasshopper_Engine/Query/AvailableHints.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.UI.Grasshopper.Objects.Hints;
+using Grasshopper.Kernel.Parameters;
+using Grasshopper.Kernel.Parameters.Hints;
+using System.Collections.Generic;
+
+namespace BH.Engine.Grasshopper
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Fields                             ****/
+        /***************************************************/
+
+        public static List<IGH_TypeHint> AvailableHints = new List<IGH_TypeHint>()
+        {
+            new GH_NullHint(),
+            new GH_HintSeparator(),
+            new BHoMObjectHint(),
+            new IGeometryHint(),
+            new DictionaryHint(),
+            new EnumHint(),
+            new TypeHint(),
+            new GH_HintSeparator(),
+            new GH_BooleanHint_CS(),
+            new GH_IntegerHint_CS(),
+            new GH_DoubleHint_CS(),
+            new GH_StringHint_CS(),
+            new GH_HintSeparator(),
+            new GH_DateTimeHint(),
+            new GH_ColorHint(),
+            new GH_GuidHint()
+        };
+
+        /***************************************************/
+    }
+}

--- a/Grasshopper_Engine/Query/Type.cs
+++ b/Grasshopper_Engine/Query/Type.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
  *
@@ -20,54 +20,54 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using Grasshopper.Kernel;
 using Grasshopper.Kernel.Parameters;
-using Grasshopper.Kernel.Types;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
+using System.Collections;
 
 namespace BH.Engine.Grasshopper
 {
-    public static partial class Convert
+    public static partial class Query
     {
-        /*******************************************/
-        /**** Public Methods                    ****/
-        /*******************************************/
+        /***************************************************/
+        /**** Public Fields                             ****/
+        /***************************************************/
 
-        public static T FromGoo<T>(this IGH_Goo goo, IGH_TypeHint hint=null)
+        public static Type Type(this IGH_TypeHint hint)
         {
-            if (goo == null)
-                return default(T);
-
-            // Get the data out of the Goo
-            object data = goo.ScriptVariable();
-            while (data is IGH_Goo)
-                data = ((IGH_Goo)data).ScriptVariable();
-
-            if (data == null)
-                return default(T);
-
-            // Convert the data to an acceptable format
-            if (data is T)
+            switch (hint.TypeName)
             {
-                return (T)data;
-            }
-            else if (hint != null)
-            {
-                hint.Cast(RuntimeHelpers.GetObjectValue(data), out object result);
-                return (T)result;
-            }
-            else
-            {
-                if (data.GetType().Namespace.StartsWith("Rhino.Geometry"))
-                    data = BH.Engine.Rhinoceros.Convert.ToBHoM(data as dynamic);
-                return (T)(data as dynamic);
+                case "null":
+                    return typeof(object);
+                case "BH.oM.Base.BHoMObject":
+                    return typeof(BH.oM.Base.BHoMObject);
+                case "BH.oM.Geometry.IGeometry":
+                    return typeof(BH.oM.Geometry.IGeometry);
+                case "Dictionary":
+                    return typeof(IDictionary);
+                case "System.Enum":
+                    return typeof(System.Enum);
+                case "System.Type":
+                    return typeof(Type);
+                case "bool":
+                    return typeof(bool);
+                case "int":
+                    return typeof(int);
+                case "double":
+                    return typeof(double);
+                case "string":
+                    return typeof(string);
+                case "DateTime":
+                    return typeof(DateTime);
+                case "Color":
+                    return typeof(System.Drawing.Color);
+                case "Guid":
+                    return typeof(Guid);
+                default:
+                    return typeof(object);
             }
         }
 
-        /*************************************/
+        /***************************************************/
     }
 }

--- a/Grasshopper_UI/2.0/NonComponents/Render/RenderBHoMGeometry.cs
+++ b/Grasshopper_UI/2.0/NonComponents/Render/RenderBHoMGeometry.cs
@@ -206,9 +206,9 @@ namespace BH.UI.Grasshopper
 
         private static Color GetBHColor(Color ghColor)
         {
-            int R = ghColor.R - 59;      // Difference to BuroHappold Green
-            int G = ghColor.G + 168;     // Difference to BuroHappold Green
-            int B = ghColor.B;           // Difference to BuroHappold Green
+            int R = ghColor.R - 59;
+            int G = ghColor.G + 168;
+            int B = ghColor.B;
             return Color.FromArgb(100, R < 255 && R > 0 ? R : 0, G < 255 && G > 0 ? G : 255, B);
         }
 

--- a/Grasshopper_UI/2.1/Components/Engine/Explode.cs
+++ b/Grasshopper_UI/2.1/Components/Engine/Explode.cs
@@ -21,6 +21,7 @@
  */
 
 using System;
+using GH = Grasshopper;
 using Grasshopper.Kernel;
 using BH.oM.Base;
 using BH.UI.Grasshopper.Base;
@@ -50,7 +51,7 @@ namespace BH.UI.Grasshopper.Components
 
         public ExplodeComponent() : base()
         {
-            Params.ParameterSourcesChanged += Params_ParameterSourcesChanged;
+            Params.ParameterChanged += (sender, e) => UpdateOutputs(false);
         }
 
 
@@ -80,15 +81,9 @@ namespace BH.UI.Grasshopper.Components
             base.AppendAdditionalComponentMenuItems(menu);
         }
 
+
         /*******************************************/
         /**** Private Methods                   ****/
-        /*******************************************/
-
-        private void Params_ParameterSourcesChanged(object sender, GH_ParamServerEventArgs e)
-        {
-            UpdateOutputs(false);
-        }
-
         /*******************************************/
 
         private void RefreshLabel_Click(object sender, EventArgs e)
@@ -96,6 +91,7 @@ namespace BH.UI.Grasshopper.Components
             ExpireSolution(false);
             UpdateOutputs(true);
         }
+
         /*******************************************/
 
         private void UpdateOutputs(bool ignoreAutoUpdate)

--- a/Grasshopper_UI/2.1/Components/Engine/Explode.cs
+++ b/Grasshopper_UI/2.1/Components/Engine/Explode.cs
@@ -51,7 +51,7 @@ namespace BH.UI.Grasshopper.Components
 
         public ExplodeComponent() : base()
         {
-            Params.ParameterChanged += (sender, e) => UpdateOutputs(false);
+            Params.ParameterSourcesChanged += (sender, e) => UpdateOutputs(false);
         }
 
 

--- a/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
+++ b/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
@@ -43,15 +43,6 @@ namespace BH.UI.Grasshopper.Components
 
 
         /*******************************************/
-        /**** Constructors                      ****/
-        /*******************************************/
-
-        public CreateCustomComponent() : base()
-        {
-            Params.ParameterChanged += (sender, e) => RefreshComponent();
-        }
-
-        /*******************************************/
         /**** Override Methods                  ****/
         /*******************************************/
 
@@ -82,7 +73,8 @@ namespace BH.UI.Grasshopper.Components
         {
             Param_ScriptVariable param = new Param_ScriptVariable
             {
-                NickName = GH_ComponentParamServer.InventUniqueNickname("xyzuvw", this.Params.Input)
+                NickName = GH_ComponentParamServer.InventUniqueNickname("xyzuvw", this.Params.Input),
+                TypeHint = new GH_NullHint()
             };
             return param;
         }

--- a/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
+++ b/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
@@ -85,6 +85,7 @@ namespace BH.UI.Grasshopper.Components
         public override void VariableParameterMaintenance()
         {
             CreateCustomCaller caller = Caller as CreateCustomCaller;
+            Params.Input.RemoveAll(p => p.Name == "CustomData");
 
             List<string> nicknames = new List<string>();
             foreach(IGH_Param param in Params.Input)

--- a/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
+++ b/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
@@ -50,7 +50,10 @@ namespace BH.UI.Grasshopper.Components
             // (Deserialisation happens after RegisterInputParams so the caller has not had a chance to retreive its input list yet)
 
             if (Caller is CreateCustomCaller caller)
+            {
+                caller.ItemSelected += (sender, e) => base.RegisterInputParams(pManager);
                 caller.SetInputs(Params.Input.Select(x => x.NickName).ToList());
+            }
         }
 
         /*******************************************/

--- a/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
+++ b/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
@@ -41,6 +41,11 @@ namespace BH.UI.Grasshopper.Components
 
         public override Caller Caller { get; } = new CreateCustomCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
         public CreateCustomComponent() : base()
         {
             Params.ParameterChanged += (sender, e) => RefreshComponent();

--- a/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
+++ b/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
@@ -27,6 +27,7 @@ using BH.UI.Components;
 using System.Linq;
 using System.Collections.Generic;
 using Grasshopper.Kernel.Parameters;
+using GH_IO.Serialization;
 
 namespace BH.UI.Grasshopper.Components
 {
@@ -47,9 +48,8 @@ namespace BH.UI.Grasshopper.Components
         {
             // Let this component be in charge of storing the inputs 
             // (Deserialisation happens after RegisterInputParams so the caller has not had a chance to retreive its input list yet)
-            CreateCustomCaller caller = Caller as CreateCustomCaller;
 
-            if (caller != null)
+            if (Caller is CreateCustomCaller caller)
                 caller.SetInputs(Params.Input.Select(x => x.NickName).ToList());
         }
 
@@ -94,6 +94,16 @@ namespace BH.UI.Grasshopper.Components
                 }
             }
             caller.SetInputs(nicknames);
+        }
+
+        /*******************************************/
+
+        public override bool Read(GH_IReader reader)
+        {
+            if (!base.Read(reader) || !Params.Read(reader))
+                return false;
+
+            return true;
         }
 
         /*******************************************/

--- a/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
+++ b/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
@@ -30,6 +30,7 @@ using Grasshopper.Kernel.Parameters;
 using GH_IO.Serialization;
 using System.Runtime.CompilerServices;
 using System;
+using Grasshopper.Kernel.Parameters.Hints;
 
 namespace BH.UI.Grasshopper.Components
 {

--- a/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
+++ b/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
@@ -20,15 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
 using Grasshopper.Kernel;
-using BH.oM.Base;
-using BH.UI.Grasshopper.Base;
 using BH.UI.Grasshopper.Templates;
 using BH.UI.Templates;
 using BH.UI.Components;
 using System.Linq;
-using BH.Engine.Grasshopper;
 using System.Collections.Generic;
 using Grasshopper.Kernel.Parameters;
 
@@ -86,7 +82,18 @@ namespace BH.UI.Grasshopper.Components
         public override void VariableParameterMaintenance()
         {
             CreateCustomCaller caller = Caller as CreateCustomCaller;
-            caller.SetInputs(Params.Input.Select(x => x.NickName).ToList());
+
+            List<string> nicknames = new List<string>();
+            foreach(IGH_Param param in Params.Input)
+            {
+                if (param is Param_ScriptVariable paramScriptVariable)
+                {
+                    paramScriptVariable.ShowHints = true;
+                    paramScriptVariable.Hints = Engine.Grasshopper.Query.AvailableHints;
+                    nicknames.Add(paramScriptVariable.NickName);
+                }
+            }
+            caller.SetInputs(nicknames);
         }
 
         /*******************************************/

--- a/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
+++ b/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
@@ -41,6 +41,10 @@ namespace BH.UI.Grasshopper.Components
 
         public override Caller Caller { get; } = new CreateCustomCaller();
 
+        public CreateCustomComponent() : base()
+        {
+            Params.ParameterChanged += (sender, e) => RefreshComponent();
+        }
 
         /*******************************************/
         /**** Override Methods                  ****/

--- a/Grasshopper_UI/2.1/Templates/CallerComponent.cs
+++ b/Grasshopper_UI/2.1/Templates/CallerComponent.cs
@@ -111,7 +111,7 @@ namespace BH.UI.Grasshopper.Templates
         /**** Override Methods                  ****/
         /*******************************************/
 
-        protected override void RegisterInputParams(GH_InputParamManager pManager)
+        protected override void RegisterInputParams(GH_InputParamManager pManager = null)
         {
             if (Caller == null)
                 return;

--- a/Grasshopper_UI/2.1/Templates/CallerComponent.cs
+++ b/Grasshopper_UI/2.1/Templates/CallerComponent.cs
@@ -78,6 +78,7 @@ namespace BH.UI.Grasshopper.Templates
 
             Caller.ItemSelected += (sender, e) => RefreshComponent();
             Caller.SolutionExpired += (sender, e) => ExpireSolution(true);
+            Params.ParameterChanged += (sender, e) => RefreshComponent();
         }
 
         /*******************************************/
@@ -125,7 +126,7 @@ namespace BH.UI.Grasshopper.Templates
                 if (newParam.GetType() != Params.Input[i].GetType())
                     Params.Input[i] = newParam;
             }
-                
+
             for (int i = nbOld - 1; i >= nbNew; i--)
                 Params.UnregisterInputParameter(Params.Input[i]);
 
@@ -159,7 +160,7 @@ namespace BH.UI.Grasshopper.Templates
                     Params.Output[i] = newParam;
                 }
             }
-                
+
             for (int i = nbOld - 1; i >= nbNew; i--)
                 Params.UnregisterOutputParameter(Params.Output[i]);
 
@@ -304,7 +305,7 @@ namespace BH.UI.Grasshopper.Templates
                             param = new Param_ScriptVariable();
                             param.AttributesChanged += Param_AttributesChanged;
                         }
-                            
+
                     }
                     break;
             }


### PR DESCRIPTION
**Depends on https://github.com/BHoM/BHoM_UI/pull/61**

---

<s>`Fixes #302`
It adds a listener to parameters changes into the `CreateCustomComponent`. </s>

Fixes #307 
This is reinstating the grasshopper hints we had in the v2.0 to its previous state. It also properly implements their `Cast` methods. Serialization works ok, the hints are kept.

<s>`Fixes #308`
More of a pain, I went for the minimal change to avoid breaking other behaviours.
The problem was that the `Read` method was reading the class schema from our usual json string. Properties added at runtime were excluded from it.
I am essentially bypassing the json part.</s>

---

Test files are here!
307: https://burohappold.sharepoint.com/:u:/s/BHoM/EcVVCA6NPuBHq0-b7eau3l4B17XUSxcsCpcxmSr8qZRqeg?e=Sa40G2

308: https://burohappold.sharepoint.com/:u:/s/BHoM/Eddj17WkX-BBqPTC5yX9mp0BIqu3rnJffkRk7r_tmbAwrw?e=qdjv4e

You can test 302 by changing a parameter name while an explode component is connected.

Direct download for open access:
[Reinstating CreateCustom functionalities- Issues 302 307 and 308.zip](https://github.com/BHoM/Grasshopper_Toolkit/files/2727981/Reinstating.CreateCustom.functionalities-.Issues.302.307.and.308.zip)

