### PR TITLE
Grasshopper toolki issue315+316 handling lists correctly

### DIFF
--- a/Grasshopper_Engine/Create/DataTree.cs
+++ b/Grasshopper_Engine/Create/DataTree.cs
@@ -65,7 +65,7 @@ namespace BH.Engine.Grasshopper
             {
                 for (int i = 0; i < data.Count; i++)
                 {
-                    DataTree<T> local = new DataTree<T>(data[i], paths[i]);
+                    DataTree<T> local = new DataTree<T>(data[i], paths[iteration]);
                     GH_Path path = paths[iteration].AppendElement(i);
                     master.EnsurePath(path);
                     master.AddRange(data[i], path);

--- a/Grasshopper_Engine/Query/Type.cs
+++ b/Grasshopper_Engine/Query/Type.cs
@@ -24,6 +24,7 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Parameters;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace BH.Engine.Grasshopper
 {
@@ -33,38 +34,53 @@ namespace BH.Engine.Grasshopper
         /**** Public Fields                             ****/
         /***************************************************/
 
-        public static Type Type(this IGH_TypeHint hint)
+        public static Type Type(this IGH_TypeHint hint, GH_ParamAccess access)
         {
             switch (hint.TypeName)
             {
                 case "null":
-                    return typeof(object);
+                    return Type<object>(access);
                 case "BH.oM.Base.BHoMObject":
-                    return typeof(BH.oM.Base.BHoMObject);
+                    return Type<BH.oM.Base.BHoMObject>(access);
                 case "BH.oM.Geometry.IGeometry":
-                    return typeof(BH.oM.Geometry.IGeometry);
+                    return Type<BH.oM.Geometry.IGeometry>(access);
                 case "Dictionary":
-                    return typeof(IDictionary);
+                    return Type<IDictionary>(access);
                 case "System.Enum":
-                    return typeof(System.Enum);
+                    return Type<System.Enum>(access);
                 case "System.Type":
-                    return typeof(Type);
+                    return Type<Type>(access);
                 case "bool":
-                    return typeof(bool);
+                    return Type<bool>(access);
                 case "int":
-                    return typeof(int);
+                    return Type<int>(access);
                 case "double":
-                    return typeof(double);
+                    return Type<double>(access);
                 case "string":
-                    return typeof(string);
+                    return Type<string>(access);
                 case "DateTime":
-                    return typeof(DateTime);
+                    return Type<DateTime>(access);
                 case "Color":
-                    return typeof(System.Drawing.Color);
+                    return Type<System.Drawing.Color>(access);
                 case "Guid":
-                    return typeof(Guid);
+                    return Type<Guid>(access);
                 default:
-                    return typeof(object);
+                    return Type<object>(access);
+            }
+        }
+
+        /***************************************************/
+
+        public static Type Type<T>(GH_ParamAccess access)
+        {
+            switch (access)
+            {
+                default:
+                    return typeof(T);
+                case GH_ParamAccess.list:
+                    return typeof(List<T>);
+                case GH_ParamAccess.tree:
+                    return typeof(List<List<T>>);
             }
         }
 

--- a/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
+++ b/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
@@ -44,6 +44,16 @@ namespace BH.UI.Grasshopper.Components
 
 
         /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public CreateCustomComponent() : base()
+        {
+            Params.ParameterChanged += SyncParamsFromGH;
+        }
+
+
+        /*******************************************/
         /**** Override Methods                  ****/
         /*******************************************/
 
@@ -89,7 +99,7 @@ namespace BH.UI.Grasshopper.Components
 
         /*******************************************/
 
-        private void SyncParamsFromGH()
+        private void SyncParamsFromGH(object sender = null, EventArgs e = null)
         {
             if (Caller is CreateCustomCaller caller)
             {
@@ -102,12 +112,8 @@ namespace BH.UI.Grasshopper.Components
                     {
                         paramScript.ShowHints = true;
                         paramScript.Hints = Engine.Grasshopper.Query.AvailableHints;
-                        if (paramScript.TypeHint != null)
-                        {
-                            types.Add(Engine.Grasshopper.Query.Type(paramScript.TypeHint));
-                        }
-                        else
-                            types.Add(typeof(object));
+                        paramScript.AllowTreeAccess = true;
+                        types.Add(Engine.Grasshopper.Query.Type(paramScript.TypeHint, paramScript.Access));
                     }
                     else
                     {
@@ -115,7 +121,7 @@ namespace BH.UI.Grasshopper.Components
                     }
                     nicknames.Add(name);
                 }
-
+                caller.SetDataAccessor(Accessor);
                 caller.SetInputs(nicknames, types);
             }
         }

--- a/Grasshopper_UI/2.1/Templates/CallerComponent.cs
+++ b/Grasshopper_UI/2.1/Templates/CallerComponent.cs
@@ -104,7 +104,11 @@ namespace BH.UI.Grasshopper.Templates
             this.RegisterOutputParams(null); // We call its bits individually: input, output 
             this.Params.OnParametersChanged(); // and ask to update the layout with OnParametersChanged()
 
-            ExpireSolution(true);
+            GH_Document document = OnPingDocument(); // when a solution is running the document of the component is set to null
+            if (document != null && document.Owner != null) // this prevents expiring a solution while another solution is running
+            {
+                ExpireSolution(true);
+            }
         }
 
 

--- a/Grasshopper_UI/2.1/Templates/CallerComponent.cs
+++ b/Grasshopper_UI/2.1/Templates/CallerComponent.cs
@@ -50,6 +50,8 @@ namespace BH.UI.Grasshopper.Templates
 
         public abstract Caller Caller { get; }
 
+        public DataAccessor_GH Accessor = null;
+
         protected override System.Drawing.Bitmap Internal_Icon_24x24 { get { return Caller.Icon_24x24; } }
 
         public override Guid ComponentGuid { get { return Caller.Id; } }
@@ -73,12 +75,11 @@ namespace BH.UI.Grasshopper.Templates
             Category = "BHoM";
             SubCategory = Caller.Category;
 
-            m_Accessor = new DataAccessor_GH(this);
-            Caller.SetDataAccessor(m_Accessor);
+            Accessor = new DataAccessor_GH(this);
+            Caller.SetDataAccessor(Accessor);
 
             Caller.ItemSelected += (sender, e) => RefreshComponent();
             Caller.SolutionExpired += (sender, e) => ExpireSolution(true);
-            Params.ParameterChanged += (sender, e) => RefreshComponent();
         }
 
         /*******************************************/
@@ -136,7 +137,7 @@ namespace BH.UI.Grasshopper.Templates
 
         /*******************************************/
 
-        protected override void RegisterOutputParams(GH_OutputParamManager pManager)
+        protected override void RegisterOutputParams(GH_OutputParamManager pManager = null)
         {
             if (Caller == null)
                 return;
@@ -172,7 +173,7 @@ namespace BH.UI.Grasshopper.Templates
 
         protected override void SolveInstance(IGH_DataAccess DA)
         {
-            m_Accessor.GH_Accessor = DA;
+            Accessor.GH_Accessor = DA;
             Caller.Run();
             Logging.ShowEvents(this, BH.Engine.Reflection.Query.CurrentEvents());
         }
@@ -330,16 +331,7 @@ namespace BH.UI.Grasshopper.Templates
 
         private void Param_AttributesChanged(IGH_DocumentObject sender, GH_AttributesChangedEventArgs e)
         {
-            Caller.SetDataAccessor(m_Accessor);
+            Caller.SetDataAccessor(Accessor);
         }
-
-
-        /*******************************************/
-        /**** Private Fields                    ****/
-        /*******************************************/
-
-        private DataAccessor_GH m_Accessor = null;
-
-        /*******************************************/
     }
 }


### PR DESCRIPTION
Depends on https://github.com/BHoM/BHoM_UI/pull/65

Fixes #315 
This is doing two things: registering the correct type of the object and setting the setting the `DataAccessor` at every component update. For the latter I had to expose `CallerComponent.m_Accessor` publicly. I noticed a weird inheritance chain (Accessor owning the component and then component owning the Accessor), but I hope this is fine in terms of architecture (@adecler).

Fixes #316 
This was a BHoM_UI problem, it has been solved in the dependent pull request.

You can test this with:
https://burohappold.sharepoint.com/:u:/s/BHoM/EQ0-nZ87JpZNmelkOgfPQa8BfEWJaFM3-4pCC1TUVLgxPA?e=YweP8k