### PR TITLE
Fixes #312 - Do not reset 2.0 components if they fail to deserialise

### DIFF
--- a/Grasshopper_Engine/Convert/ToType.cs
+++ b/Grasshopper_Engine/Convert/ToType.cs
@@ -59,7 +59,17 @@ namespace BH.Engine.Grasshopper
             if (parts.Length == 0)
                 return null;
             else
-                return BH.Engine.Reflection.Create.Type(parts[0]);
+            {
+                try
+                {
+                    type = BH.Engine.Reflection.Create.Type(parts[0]);
+                }
+                catch
+                {
+                    type = typeof(object);
+                }
+                return type;
+            }
         }
 
         /*******************************************/

--- a/Grasshopper_UI/2.0/Templates/MethodCallTemplate.cs
+++ b/Grasshopper_UI/2.0/Templates/MethodCallTemplate.cs
@@ -293,13 +293,13 @@ namespace BH.UI.Grasshopper.Templates
                 Type type = typeString.ToType();
                 RestoreMethod(type, methodName, paramTypes);
 
-                m_IsDeprecated |= m_Method.IsDeprecated();
-                m_IsNotImplemented = m_Method.IsNotImplemented();
-                m_IsReleased = m_Method.IsReleased();
 
                 // Restore the ports
                 if (m_Method != null)
                 {
+                    m_IsDeprecated |= m_Method.IsDeprecated();
+                    m_IsNotImplemented = m_Method.IsNotImplemented();
+                    m_IsReleased = m_Method.IsReleased();
                     Type outputType = (m_Method is MethodInfo) ? ((MethodInfo)m_Method).ReturnType : m_Method.DeclaringType;
                     ComputeDaGets(m_Method.GetParameters().ToList(), outputType);
                 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #312
<!-- Add short description of what has been fixed -->
v2.0 components run into a type not found exception, because of major changes in the BHoM and other toolkits. Preventing the exception by moving the m_Method set operations into the null guard and adding a try-catch for the creation of the type. The `ToType` method is only used by the v2.0 components.

### Test files
<!-- Link to test files to validate the proposed changes -->
You can use the unit tests to check if the errors persists. Below is a good example (try it before and after switching to this branch). You can also make use of any other script that contains old UI components to test this.
https://burohappold.sharepoint.com/:u:/s/BHoM/EYH3MBD5ihdJrBwkb6OHTWoBGJjCIIvHJvLfT7CGmVBlsQ?e=q55wQ6

### Definition of Done
If the components do not reset themselves (turn red, no input, no outputs, and get thrown at the origin of the grasshopper canvas), the fix is successful.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->