### PR TITLE
Grasshopper ui issue314 update component correctly explode

### DIFF
--- a/Grasshopper_UI/2.1/Components/Engine/Explode.cs
+++ b/Grasshopper_UI/2.1/Components/Engine/Explode.cs
@@ -76,16 +76,8 @@ namespace BH.UI.Grasshopper.Components
         {
             this.OnGrasshopperUpdates();
 
-            if (this.IsExpired())
-            {
-                Engine.Reflection.Compute.ClearCurrentEvents();
-                Engine.Reflection.Compute.RecordWarning("Output paramters do not match object properties. Please right click and <Update Outputs>");
-                Logging.ShowEvents(this, BH.Engine.Reflection.Query.CurrentEvents());
-            }
-            else
-            {
+            if (!this.IsExpired())
                 base.SolveInstance(DA);
-            }
         }
 
         /*******************************************/
@@ -93,8 +85,24 @@ namespace BH.UI.Grasshopper.Components
         protected override void AfterSolveInstance()
         {
             if (Caller.OutputParams.Count != 0 & Params.Output.Count == 0)
+            {
                 this.OnBHoMUpdates();
-            base.BeforeSolveInstance();
+            }
+            else if (this.IsExpired())
+            {
+                if (Params.Output.All(p => p.Recipients.Count == 0))
+                {
+                    this.OnBHoMUpdates();
+                }
+                else
+                {
+                    Engine.Reflection.Compute.ClearCurrentEvents();
+                    Engine.Reflection.Compute.RecordWarning("Output paramters do not match object properties. Please right click and <Update Outputs>");
+                    Logging.ShowEvents(this, BH.Engine.Reflection.Query.CurrentEvents());
+                }
+            }
+
+            base.AfterSolveInstance();
         }
 
         /*******************************************/

--- a/Grasshopper_UI/2.1/Components/Engine/Explode.cs
+++ b/Grasshopper_UI/2.1/Components/Engine/Explode.cs
@@ -47,7 +47,7 @@ namespace BH.UI.Grasshopper.Components
         /**** Public Override Methods           ****/
         /*******************************************/
 
-        public override void OnBHoMUpdates(object sender = null, object e = null)
+        public void OnBHoMUpdates(object sender = null, object e = null)
         {
             RecordUndoEvent("OnBHoMUpdates");
             // Forces the component to update
@@ -58,7 +58,7 @@ namespace BH.UI.Grasshopper.Components
 
         /*******************************************/
 
-        public override void OnGrasshopperUpdates(object sender = null, object e = null)
+        public void OnGrasshopperUpdates(object sender = null, object e = null)
         {
             // Update the output params based on input data
             Params.Input[0].CollectData();

--- a/Grasshopper_UI/2.1/Components/Engine/Explode.cs
+++ b/Grasshopper_UI/2.1/Components/Engine/Explode.cs
@@ -84,7 +84,7 @@ namespace BH.UI.Grasshopper.Components
 
         protected override void AfterSolveInstance()
         {
-            if (Caller.OutputParams.Count != 0 & Params.Output.Count == 0)
+            if (Caller.OutputParams.Count != 0 && Params.Output.Count == 0)
             {
                 this.OnBHoMUpdates();
             }
@@ -120,7 +120,7 @@ namespace BH.UI.Grasshopper.Components
 
         private bool IsExpired()
         {
-            if (Caller.OutputParams.Count == 0 | Params.Output.Count == 0)
+            if (Caller.OutputParams.Count == 0 || Params.Output.Count == 0)
             {
                 return true;
             }

--- a/Grasshopper_UI/2.1/Components/Engine/Explode.cs
+++ b/Grasshopper_UI/2.1/Components/Engine/Explode.cs
@@ -59,6 +59,7 @@ namespace BH.UI.Grasshopper.Components
 
         public override void OnBHoMUpdates(object sender = null, object e = null)
         {
+            RecordUndoEvent("OnBHoMUpdates");
             // Forces the component to update
             this.RegisterOutputParams();
             this.Params.OnParametersChanged();

--- a/Grasshopper_UI/2.1/Components/Engine/Explode.cs
+++ b/Grasshopper_UI/2.1/Components/Engine/Explode.cs
@@ -44,16 +44,6 @@ namespace BH.UI.Grasshopper.Components
 
 
         /*******************************************/
-        /**** Constructors                      ****/
-        /*******************************************/
-
-        public ExplodeComponent() : base()
-        {
-            //this.Params.ParameterSourcesChanged += OnGrasshopperUpdates;
-        }
-
-
-        /*******************************************/
         /**** Public Override Methods           ****/
         /*******************************************/
 

--- a/Grasshopper_UI/2.1/Components/Engine/Explode.cs
+++ b/Grasshopper_UI/2.1/Components/Engine/Explode.cs
@@ -49,7 +49,7 @@ namespace BH.UI.Grasshopper.Components
 
         public ExplodeComponent() : base()
         {
-            this.Params.ParameterSourcesChanged += OnGrasshopperUpdates;
+            //this.Params.ParameterSourcesChanged += OnGrasshopperUpdates;
         }
 
 

--- a/Grasshopper_UI/2.1/Components/UI/UpdateVersion.cs
+++ b/Grasshopper_UI/2.1/Components/UI/UpdateVersion.cs
@@ -209,7 +209,7 @@ namespace BH.UI.Grasshopper.Base
             if (selectedItem != null)
             {
                 newComp.Caller.SetItem(selectedItem);
-                newComp.OnBHoMUpdates();
+                newComp.OnItemSelected();
             }
                 
             // Copy the links over
@@ -397,7 +397,7 @@ namespace BH.UI.Grasshopper.Base
             CreateCustomComponent newComp = new CreateCustomComponent();
             CreateCustomCaller caller = newComp.Caller as CreateCustomCaller;
             caller.SetInputs(component.Params.Input.Select(x => x.NickName).ToList());
-            newComp.OnBHoMUpdates();
+            newComp.OnItemSelected();
 
             return SwapComponent(doc, component, newComp, component.SelectedType);
         }

--- a/Grasshopper_UI/2.1/Components/UI/UpdateVersion.cs
+++ b/Grasshopper_UI/2.1/Components/UI/UpdateVersion.cs
@@ -209,7 +209,7 @@ namespace BH.UI.Grasshopper.Base
             if (selectedItem != null)
             {
                 newComp.Caller.SetItem(selectedItem);
-                newComp.RefreshComponent();
+                newComp.OnBHoMUpdates();
             }
                 
             // Copy the links over
@@ -341,7 +341,6 @@ namespace BH.UI.Grasshopper.Base
         private static bool ReplaceObsolete(GH_Document doc, ExplodeJson component)
         {
             ExplodeComponent newComp = new ExplodeComponent();
-            newComp.AutoUpdateOutputs = false;
 
             foreach (IGH_Param param in component.Params.Output)
                 newComp.Params.RegisterOutputParam(GetNewParam(param as dynamic));
@@ -398,7 +397,7 @@ namespace BH.UI.Grasshopper.Base
             CreateCustomComponent newComp = new CreateCustomComponent();
             CreateCustomCaller caller = newComp.Caller as CreateCustomCaller;
             caller.SetInputs(component.Params.Input.Select(x => x.NickName).ToList());
-            newComp.RefreshComponent();
+            newComp.OnBHoMUpdates();
 
             return SwapComponent(doc, component, newComp, component.SelectedType);
         }

--- a/Grasshopper_UI/2.1/Components/oM/CreateType.cs
+++ b/Grasshopper_UI/2.1/Components/oM/CreateType.cs
@@ -44,9 +44,9 @@ namespace BH.UI.Grasshopper.Components
         /**** Private Methods                   ****/
         /*******************************************/
 
-        public override void OnBHoMUpdates(object sender, object e)
+        public override void OnItemSelected(object sender, object e)
         {
-            base.OnBHoMUpdates();
+            base.OnItemSelected();
 
             Type type = Caller.SelectedItem as Type;
             if (type != null)

--- a/Grasshopper_UI/2.1/Components/oM/CreateType.cs
+++ b/Grasshopper_UI/2.1/Components/oM/CreateType.cs
@@ -44,9 +44,9 @@ namespace BH.UI.Grasshopper.Components
         /**** Private Methods                   ****/
         /*******************************************/
 
-        public override void RefreshComponent()
+        public override void OnBHoMUpdates(object sender, object e)
         {
-            base.RefreshComponent();
+            base.OnBHoMUpdates();
 
             Type type = Caller.SelectedItem as Type;
             if (type != null)

--- a/Grasshopper_UI/2.1/Components/oM/CreateType.cs
+++ b/Grasshopper_UI/2.1/Components/oM/CreateType.cs
@@ -51,8 +51,9 @@ namespace BH.UI.Grasshopper.Components
             Type type = Caller.SelectedItem as Type;
             if (type != null)
                 Message = type.ToText();
-        }
 
+            ExpireSolution(true);
+        }
 
         /*******************************************/
     }

--- a/Grasshopper_UI/2.1/Components/oM/CreateType.cs
+++ b/Grasshopper_UI/2.1/Components/oM/CreateType.cs
@@ -51,8 +51,6 @@ namespace BH.UI.Grasshopper.Components
             Type type = Caller.SelectedItem as Type;
             if (type != null)
                 Message = type.ToText();
-
-            ExpireSolution(true);
         }
 
         /*******************************************/

--- a/Grasshopper_UI/2.1/Templates/CallerComponent.cs
+++ b/Grasshopper_UI/2.1/Templates/CallerComponent.cs
@@ -104,14 +104,7 @@ namespace BH.UI.Grasshopper.Templates
             this.RegisterOutputParams(null); // We call its bits individually: input, output 
             this.Params.OnParametersChanged(); // and ask to update the layout with OnParametersChanged()
 
-            if (Caller.InputParams.Count == 0 | Caller.InputParams.All(p => p.HasDefaultValue))
-            {
-                this.ExpireSolution(true);
-            }
-            else
-            {
-                this.OnDisplayExpired(true);
-            }
+            this.ExpireSolution(true);
         }
 
 

--- a/Grasshopper_UI/2.1/Templates/CallerComponent.cs
+++ b/Grasshopper_UI/2.1/Templates/CallerComponent.cs
@@ -114,14 +114,6 @@ namespace BH.UI.Grasshopper.Templates
             }
         }
 
-        /*******************************************/
-
-        public virtual void OnBHoMUpdates(object sender = null, object e = null) { }
-
-        /*******************************************/
-
-        public virtual void OnGrasshopperUpdates(object sender, object e = null) { }
-
 
         /*******************************************/
         /**** Override Methods                  ****/

--- a/Grasshopper_UI/2.1/Templates/CallerComponent.cs
+++ b/Grasshopper_UI/2.1/Templates/CallerComponent.cs
@@ -78,7 +78,7 @@ namespace BH.UI.Grasshopper.Templates
             Accessor = new DataAccessor_GH(this);
             Caller.SetDataAccessor(Accessor);
 
-            Caller.ItemSelected += (sender, e) => RefreshComponent();
+            Caller.ItemSelected += OnItemSelected;
             Caller.SolutionExpired += (sender, e) => ExpireSolution(true);
         }
 
@@ -94,7 +94,7 @@ namespace BH.UI.Grasshopper.Templates
         /**** Public Methods                    ****/
         /*******************************************/
 
-        public virtual void RefreshComponent()
+        public virtual void OnItemSelected(object sender = null, object e = null)
         {
             Name = Caller.Name;
             NickName = Caller.Name;
@@ -104,12 +104,16 @@ namespace BH.UI.Grasshopper.Templates
             this.RegisterOutputParams(null); // We call its bits individually: input, output 
             this.Params.OnParametersChanged(); // and ask to update the layout with OnParametersChanged()
 
-            GH_Document document = OnPingDocument(); // when a solution is running the document of the component is set to null
-            if (document != null) // this prevents expiring a solution while another solution is running
-            {
-                ExpireSolution(true);
-            }
+            this.OnDisplayExpired(true);
         }
+
+        /*******************************************/
+
+        public virtual void OnBHoMUpdates(object sender = null, object e = null) { }
+
+        /*******************************************/
+
+        public virtual void OnGrasshopperUpdates(object sender, object e = null) { }
 
 
         /*******************************************/
@@ -253,7 +257,7 @@ namespace BH.UI.Grasshopper.Templates
             object item = BH.Engine.Serialiser.Convert.FromJson(code);
             if (item != null)
                 Caller.SetItem(item);
-            RefreshComponent();
+            this.OnItemSelected();
         }
 
 

--- a/Grasshopper_UI/2.1/Templates/CallerComponent.cs
+++ b/Grasshopper_UI/2.1/Templates/CallerComponent.cs
@@ -104,7 +104,14 @@ namespace BH.UI.Grasshopper.Templates
             this.RegisterOutputParams(null); // We call its bits individually: input, output 
             this.Params.OnParametersChanged(); // and ask to update the layout with OnParametersChanged()
 
-            this.OnDisplayExpired(true);
+            if (Caller.InputParams.Count == 0 | Caller.InputParams.All(p => p.HasDefaultValue))
+            {
+                this.ExpireSolution(true);
+            }
+            else
+            {
+                this.OnDisplayExpired(true);
+            }
         }
 
         /*******************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #314 

Ok, this is the start of tweaking the Grasshopper UI to more explicitly handle the dialogue between Grasshopper itself and the BHoM_UI.
It is fixing the point where all the error were exposed: the explode component. I definitively disabled the autoupdates. The component now expires if the input changed. It auto-explode only the first time you connect an input.
Moreover, the base CallerComponent now does not expire the solution, but the display, that forces the parameter to update. CreateType now explicitly expires the solution.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
#### Changed:
- from `public virtual void CallerComponent.RefreshComponent()` to `public virtual CallerComponent.OnItemSelected(object sender = null, object e = null)`

#### Removed:
- `private void ExplodeComponent.UpdateOutputs(bool ignoreAutoUpdate)`

#### Added:
- `public virtual void CallerComponent.OnBHoMUpdates(object sender = null, object e = null)`
- `public virtual void CallerComponent.OnGrasshopperUpdates(object sender = null, object e = null)`
- `public override void ExplodeComponent.OnGrasshopperUpdates(object sender = null, object e = null)`
- `public override void ExplodeComponent.OnGrasshopperUpdates(object sender = null, object e = null)`
- `private bool ExplodeComponent.IsExpired()`


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/EaADcbbmXdJKsYYDFyzsRE0Bfe2yR4sXOYp420lb8RuZDg?e=7zogsP

### What to check
I'd rather not condition the way you test this. A general UX feedback, especially about what is annoying would be perfect.




### Additional comments
<!-- As required -->
FYI @al-fisher @rwemay 