### PR TITLE
Checking for expiration only once per run call

### DIFF
--- a/Grasshopper_UI/2.1/Components/Engine/Explode.cs
+++ b/Grasshopper_UI/2.1/Components/Engine/Explode.cs
@@ -72,10 +72,14 @@ namespace BH.UI.Grasshopper.Components
         /**** Protected Override Methods        ****/
         /*******************************************/
 
+        protected override void BeforeSolveInstance()
+        {
+            base.BeforeSolveInstance();
+            this.OnGrasshopperUpdates();
+        }
+
         protected override void SolveInstance(IGH_DataAccess DA)
         {
-            this.OnGrasshopperUpdates();
-
             if (!this.IsExpired())
                 base.SolveInstance(DA);
         }
@@ -120,7 +124,12 @@ namespace BH.UI.Grasshopper.Components
 
         private bool IsExpired()
         {
-            if (Caller.OutputParams.Count == 0 || Params.Output.Count == 0)
+            if (Params.Input.Count == 1 && Params.Input[0].SourceCount == 0) // Nothing plugged in
+            {
+                return false;
+            }
+
+            if (Caller.OutputParams.Count == 0 || Params.Output.Count == 0) 
             {
                 return true;
             }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #332

<!-- Add short description of what has been fixed -->
With a list of objects as input `SolveIntance(DA)` was called on every iteration. Moved the expiration check into `BeforeSolveIntance` to run it just once.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/ETMi8TKwJixKr4vY4HOF7uEBQ6rlQpUxZ6dQDS2vETCtGw?e=Cq4FHt

You can also test the recent test file to check that it does not revert any earlier fix:
https://burohappold.sharepoint.com/:u:/s/BHoM/EaADcbbmXdJKsYYDFyzsRE0Bfe2yR4sXOYp420lb8RuZDg?e=wp3YNy
https://burohappold.sharepoint.com/:u:/s/BHoM/EQ0-nZ87JpZNmelkOgfPQa8BfEWJaFM3-4pCC1TUVLgxPA?e=URGMgW
https://burohappold.sharepoint.com/:f:/s/BHoM/EnE8jIAZ7_hBh6HF1KOrlHABHiBMQmA4sBFXmO3n-uJ0KQ?e=TfTmDo


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->