### PR TITLE
Grasshopper_UI-Issue324-LoggingOnParameters

### DIFF
--- a/Grasshopper_UI/2.1/Components/Parameters/Param_BHoMGeometry.cs
+++ b/Grasshopper_UI/2.1/Components/Parameters/Param_BHoMGeometry.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.UI.Grasshopper.Properties;
+using GH_IO.Serialization;
 using Grasshopper.Kernel;
 using System;
 using System.Collections.Generic;
@@ -72,6 +73,16 @@ namespace BH.UI.Grasshopper.Objects
         public void DrawViewportWires(IGH_PreviewArgs args)
         {
             Preview_DrawWires(args);
+        }
+
+        /*******************************************/
+
+        public override bool Read(GH_IReader reader)
+        {
+            Engine.Reflection.Compute.ClearCurrentEvents();
+            bool success = base.Read(reader);
+            Logging.ShowEvents(this, Engine.Reflection.Query.CurrentEvents());
+            return success;
         }
 
         /*******************************************/

--- a/Grasshopper_UI/2.1/Components/Parameters/Param_BHoMObject.cs
+++ b/Grasshopper_UI/2.1/Components/Parameters/Param_BHoMObject.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.UI.Grasshopper.Properties;
+using GH_IO.Serialization;
 using Grasshopper.Kernel;
 using System;
 using System.Collections.Generic;
@@ -72,6 +73,16 @@ namespace BH.UI.Grasshopper.Objects
         public void DrawViewportWires(IGH_PreviewArgs args)
         {
             Preview_DrawWires(args);
+        }
+
+        /*******************************************/
+
+        public override bool Read(GH_IReader reader)
+        {
+            Engine.Reflection.Compute.ClearCurrentEvents();
+            bool success = base.Read(reader);
+            Logging.ShowEvents(this, Engine.Reflection.Query.CurrentEvents());
+            return success;
         }
 
         /*******************************************/

--- a/Grasshopper_UI/2.1/Components/Parameters/Param_Dictionary.cs
+++ b/Grasshopper_UI/2.1/Components/Parameters/Param_Dictionary.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.UI.Grasshopper.Properties;
+using GH_IO.Serialization;
 using Grasshopper.Kernel;
 using System;
 using System.Collections.Generic;
@@ -58,6 +59,16 @@ namespace BH.UI.Grasshopper.Objects
 
         /*******************************************/
         /**** Override Methods                  ****/
+        /*******************************************/
+
+        public override bool Read(GH_IReader reader)
+        {
+            Engine.Reflection.Compute.ClearCurrentEvents();
+            bool success = base.Read(reader);
+            Logging.ShowEvents(this, Engine.Reflection.Query.CurrentEvents());
+            return success;
+        }
+
         /*******************************************/
 
         protected override GH_GetterResult Prompt_Singular(ref Engine.Grasshopper.Objects.GH_Dictionary value)

--- a/Grasshopper_UI/2.1/Components/Parameters/Param_Enum.cs
+++ b/Grasshopper_UI/2.1/Components/Parameters/Param_Enum.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.UI.Grasshopper.Properties;
+using GH_IO.Serialization;
 using Grasshopper.Kernel;
 using System;
 using System.Collections.Generic;
@@ -57,6 +58,16 @@ namespace BH.UI.Grasshopper.Objects
 
         /*******************************************/
         /**** Override Methods                  ****/
+        /*******************************************/
+
+        public override bool Read(GH_IReader reader)
+        {
+            Engine.Reflection.Compute.ClearCurrentEvents();
+            bool success = base.Read(reader);
+            Logging.ShowEvents(this, Engine.Reflection.Query.CurrentEvents());
+            return success;
+        }
+
         /*******************************************/
 
         protected override GH_GetterResult Prompt_Singular(ref Engine.Grasshopper.Objects.GH_Enum value)

--- a/Grasshopper_UI/2.1/Components/Parameters/Param_IObject.cs
+++ b/Grasshopper_UI/2.1/Components/Parameters/Param_IObject.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.UI.Grasshopper.Properties;
+using GH_IO.Serialization;
 using Grasshopper.Kernel;
 using System;
 using System.Collections.Generic;
@@ -72,6 +73,16 @@ namespace BH.UI.Grasshopper.Objects
         public void DrawViewportWires(IGH_PreviewArgs args)
         {
             Preview_DrawWires(args);
+        }
+
+        /*******************************************/
+
+        public override bool Read(GH_IReader reader)
+        {
+            Engine.Reflection.Compute.ClearCurrentEvents();
+            bool success = base.Read(reader);
+            Logging.ShowEvents(this, Engine.Reflection.Query.CurrentEvents());
+            return success;
         }
 
         /*******************************************/

--- a/Grasshopper_UI/2.1/Components/Parameters/Param_Type.cs
+++ b/Grasshopper_UI/2.1/Components/Parameters/Param_Type.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.UI.Grasshopper.Properties;
+using GH_IO.Serialization;
 using Grasshopper.Kernel;
 using System;
 using System.Collections.Generic;
@@ -58,6 +59,16 @@ namespace BH.UI.Grasshopper.Objects
 
         /*******************************************/
         /**** Override Methods                  ****/
+        /*******************************************/
+
+        public override bool Read(GH_IReader reader)
+        {
+            Engine.Reflection.Compute.ClearCurrentEvents();
+            bool success = base.Read(reader);
+            Logging.ShowEvents(this, Engine.Reflection.Query.CurrentEvents());
+            return success;
+        }
+
         /*******************************************/
 
         protected override GH_GetterResult Prompt_Singular(ref Engine.Grasshopper.Objects.GH_Type value)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #324 
As suggested in https://github.com/BHoM/BHoM_Engine/pull/782 (@IsakNaslundBh ) parameters are now exposing the underlying BHoM log.
<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/Ev2MDDjKYmhPnvKGIIac9Q8B1H8j57uEOuH-oGTwFN7nZg?e=1nyiqu

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
#### Added:
- Param_BHoMObject.Read(GH_IReader reader)
- Param_BHoMGeometry.Read(GH_IReader reader)
- Param_Dictionary.Read(GH_IReader reader)
- Param_Enum.Read(GH_IReader reader)
- Param_IObject.Read(GH_IReader reader)
- Param_Type.Read(GH_IReader reader)

### Additional comments
<!-- As required -->