### PR TITLE
Grasshopper toolkit issue308 create custom forced type

### DIFF
--- a/Grasshopper_Engine/Convert/FromGoo.cs
+++ b/Grasshopper_Engine/Convert/FromGoo.cs
@@ -22,12 +22,7 @@
 
 using Grasshopper.Kernel.Parameters;
 using Grasshopper.Kernel.Types;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BH.Engine.Grasshopper
 {

--- a/Grasshopper_Engine/Convert/FromGoo.cs
+++ b/Grasshopper_Engine/Convert/FromGoo.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.Grasshopper
         /**** Public Methods                    ****/
         /*******************************************/
 
-        public static T FromGoo<T>(this IGH_Goo goo, IGH_TypeHint hint=null)
+        public static T FromGoo<T>(this IGH_Goo goo, IGH_TypeHint hint = null)
         {
             if (goo == null)
                 return default(T);
@@ -59,14 +59,12 @@ namespace BH.Engine.Grasshopper
             {
                 object result;
                 hint.Cast(RuntimeHelpers.GetObjectValue(data), out result);
-                return (T)result;
+                data = result;
             }
-            else
-            {
-                if (data.GetType().Namespace.StartsWith("Rhino.Geometry"))
-                    data = BH.Engine.Rhinoceros.Convert.ToBHoM(data as dynamic);
-                return (T)(data as dynamic);
-            }
+
+            if (data.GetType().Namespace.StartsWith("Rhino.Geometry"))
+                data = BH.Engine.Rhinoceros.Convert.ToBHoM(data as dynamic);
+            return (T)(data as dynamic);
         }
 
         /*************************************/

--- a/Grasshopper_Engine/Query/Type.cs
+++ b/Grasshopper_Engine/Query/Type.cs
@@ -20,6 +20,8 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.UI.Components;
+using BH.UI.Templates;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Parameters;
 using System;
@@ -34,8 +36,28 @@ namespace BH.Engine.Grasshopper
         /**** Public Fields                             ****/
         /***************************************************/
 
+        public static Type Type(this IGH_Param param, Caller caller = null)
+        {
+            if (param == null)
+                return typeof(object);
+
+            if (param is Param_ScriptVariable)
+                return Type(((Param_ScriptVariable)param).TypeHint, param.Access);
+
+            else if (caller != null && caller is CreateCustomCaller)
+                return ((CreateCustomCaller)caller).GetParam(param.NickName).DataType;
+
+            else
+                return param.Type;
+        }
+
+        /***************************************************/
+
         public static Type Type(this IGH_TypeHint hint, GH_ParamAccess access)
         {
+            if (hint == null)
+                return typeof(object);
+
             switch (hint.TypeName)
             {
                 case "null":

--- a/Grasshopper_UI/2.1/Components/Engine/Explode.cs
+++ b/Grasshopper_UI/2.1/Components/Engine/Explode.cs
@@ -20,11 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-using GH = Grasshopper;
 using Grasshopper.Kernel;
-using BH.oM.Base;
-using BH.UI.Grasshopper.Base;
 using BH.UI.Grasshopper.Templates;
 using BH.UI.Templates;
 using BH.UI.Components;

--- a/Grasshopper_UI/2.1/Components/Engine/Explode.cs
+++ b/Grasshopper_UI/2.1/Components/Engine/Explode.cs
@@ -20,14 +20,17 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using System;
+using GH = Grasshopper;
 using Grasshopper.Kernel;
+using BH.oM.Base;
+using BH.UI.Grasshopper.Base;
 using BH.UI.Grasshopper.Templates;
 using BH.UI.Templates;
 using BH.UI.Components;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
-using BH.Engine.Grasshopper;
 
 namespace BH.UI.Grasshopper.Components
 {

--- a/Grasshopper_UI/2.1/Components/Engine/Explode.cs
+++ b/Grasshopper_UI/2.1/Components/Engine/Explode.cs
@@ -31,6 +31,7 @@ using BH.UI.Components;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
+using BH.Engine.Grasshopper;
 
 namespace BH.UI.Grasshopper.Components
 {
@@ -44,7 +45,7 @@ namespace BH.UI.Grasshopper.Components
 
 
         /*******************************************/
-        /**** Public Override Methods           ****/
+        /**** Public Methods                    ****/
         /*******************************************/
 
         public void OnBHoMUpdates(object sender = null, object e = null)
@@ -129,7 +130,7 @@ namespace BH.UI.Grasshopper.Components
                 return false;
             }
 
-            if (Caller.OutputParams.Count == 0 || Params.Output.Count == 0) 
+            if ((Caller.OutputParams.Count == 0 || Params.Output.Count == 0) && Params.Input[0].SourceCount == 0) 
             {
                 return true;
             }
@@ -143,6 +144,7 @@ namespace BH.UI.Grasshopper.Components
             for (int i = 0; i < Caller.OutputParams.Count; i++)
             {
                 expired |= Caller.OutputParams[i].Name != Params.Output[i].NickName;
+                expired |= !Caller.OutputParams[i].DataType.IsAssignableFrom(Params.Output[i].Type(Caller));
                 if (expired)
                 {
                     return true;

--- a/Grasshopper_UI/2.1/Components/Engine/Explode.cs
+++ b/Grasshopper_UI/2.1/Components/Engine/Explode.cs
@@ -140,7 +140,6 @@ namespace BH.UI.Grasshopper.Components
             for (int i = 0; i < Caller.OutputParams.Count; i++)
             {
                 expired |= Caller.OutputParams[i].Name != Params.Output[i].NickName;
-                expired |= !Caller.OutputParams[i].DataType.IsAssignableFrom(Params.Output[i].Type(Caller));
                 if (expired)
                 {
                     return true;

--- a/Grasshopper_UI/2.1/Components/Engine/Explode.cs
+++ b/Grasshopper_UI/2.1/Components/Engine/Explode.cs
@@ -41,7 +41,7 @@ namespace BH.UI.Grasshopper.Components
 
 
         /*******************************************/
-        /**** Public Methods                    ****/
+        /**** Public Override Methods           ****/
         /*******************************************/
 
         public void OnBHoMUpdates(object sender = null, object e = null)
@@ -126,7 +126,7 @@ namespace BH.UI.Grasshopper.Components
                 return false;
             }
 
-            if ((Caller.OutputParams.Count == 0 || Params.Output.Count == 0) && Params.Input[0].SourceCount == 0) 
+            if (Caller.OutputParams.Count == 0 || Params.Output.Count == 0) 
             {
                 return true;
             }

--- a/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
+++ b/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using GH = Grasshopper;
 using Grasshopper.Kernel;
 using BH.UI.Grasshopper.Templates;
 using BH.UI.Templates;
@@ -27,6 +28,7 @@ using BH.UI.Components;
 using Grasshopper.Kernel.Parameters;
 using Grasshopper.Kernel.Parameters.Hints;
 using BH.Engine.Grasshopper;
+using System.Linq;
 
 namespace BH.UI.Grasshopper.Components
 {
@@ -79,7 +81,8 @@ namespace BH.UI.Grasshopper.Components
                         return;
 
                     caller.UpdateInput(index, param.NickName, param.Type(caller)); // We update the InputParams with the new type
-                    ExpireSolution(this.Phase == GH_SolutionPhase.Computed); // We recompute only if there is no other scheduled solution running
+                    // We recompute only if there is no other scheduled solution running or the gh is not rendering any capsule or parameter
+                    ExpireSolution(this.Phase == GH_SolutionPhase.Computed && !param.Sources.Any(p => p.Attributes.GetTopLevel.DocObject is ExplodeComponent));
                     return;
             }
         }

--- a/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
+++ b/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
@@ -20,7 +20,6 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using GH = Grasshopper;
 using Grasshopper.Kernel;
 using BH.UI.Grasshopper.Templates;
 using BH.UI.Templates;

--- a/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
+++ b/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
@@ -74,14 +74,12 @@ namespace BH.UI.Grasshopper.Components
                 case "DestroyParameter":
                     caller.RemoveInput(param.NickName);
                     return;
-                case "ParameterChanged":
-                    // Fired when TypeHint or Access change.
-                    // We update the caller with the new type and let SolveIntance set the new Accessor
+                case "ParameterChanged": // Fired when TypeHint, Access or Nickname change.
                     if (index == -1)
                         return;
 
-                    caller.UpdateInput(index, param.NickName, param.Type(caller));
-                    ExpireSolution(false); // If only NickName has changed grasshopper does not recompute the solution, so we explicitly do it
+                    caller.UpdateInput(index, param.NickName, param.Type(caller)); // We update the InputParams with the new type
+                    ExpireSolution(this.Phase == GH_SolutionPhase.Computed); // We recompute only if there is no other scheduled solution running
                     return;
             }
         }

--- a/Grasshopper_UI/packages.config
+++ b/Grasshopper_UI/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Grasshopper" version="0.9.76" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="RhinoCommon" version="5.12.50810.13095" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on https://github.com/BHoM/BHoM_UI/pull/76
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #308 
Closes #302 
This pr is:
- Reinstating the possibility of forcing a type when creating a custom, and making the Grasshopper component respond to that. 
- Updating the component when a parameter name changes 
- While checking that the `TypeHint` for IBHoMGeometry is working I noticed another issue that required fix: the `FromGoo` method now always checks if the type is a Rhino type and converts to BHoM if necessary. In the current master branch it was failing because it was returning a Rhino object.
- It removes an old dependency to `Newtonsoft.json`

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EipGf_yyhclLi5qeS8b_IkIBuQAnJGPmVQlYhup_4jkLew?e=ZsyynE

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
#### Added:
- `public static Type Type(this IGH_Param param, Caller caller = null)`
- `public override bool DestroyParameter(GH_ParameterSide side, int index)`
- `public void OnGrasshopperUpdates(object sender, IGH_Param param)`
- `public override bool DestroyParameter(GH_ParameterSide side, int index)`

#### Removed:
- `protected override void RegisterInputParams(GH_InputParamManager pManager)`
- `private void SyncParamsFromGH(object sender = null, EventArgs e = null)`

### Additional comments
<!-- As required -->
**N.B. 1** This pr is breaking the (de)serialisation of previous `CreateCustomComponent`s. They do  (de)serialise but the result is incorrect.

**N.B. 2** So, the way the events for creation, destruction and update of the parameters are handled are a little hacky. This is because we are not able create an instance of `Grasshopper.Kernel.GH_ParamServerEventArgs` - its constructor is not accessible.
My first solution was to access the private constructor via reflection and create an instance of it, but I found it more hacky than the current solution. Don't hesitate to chip in, as there may be a better solution.