### PR TITLE
Flattening `objects` input of Push component

### DIFF
--- a/Grasshopper_UI/2.1/Components/Adapter/Push.cs
+++ b/Grasshopper_UI/2.1/Components/Adapter/Push.cs
@@ -40,5 +40,16 @@ namespace BH.UI.Grasshopper.Components
 
 
         /*******************************************/
+        /**** Override Methods                  ****/
+        /*******************************************/
+
+        protected override void RegisterInputParams(GH_InputParamManager pManager = null)
+        {
+            base.RegisterInputParams(pManager);
+            if (Params.Input.Count > 1)
+                pManager[1].DataMapping = GH_DataMapping.Flatten;
+        }
+
+        /*******************************************/
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #334 

<!-- Add short description of what has been fixed -->
This pr works to provide the `objects` input of the Push component as flatten data
@ZiolkowskiJakub FYI, not sure if this is relevant for Dynamo as well.

### Test files
<!-- Link to test files to validate the proposed changes -->
You can just drop a Push component on the canvas to check it.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->