### PR TITLE
Issue340 - Improve rendering performance

### DIFF
--- a/Grasshopper_Engine/Compute/RenderMeshes.cs
+++ b/Grasshopper_Engine/Compute/RenderMeshes.cs
@@ -49,7 +49,6 @@ namespace BH.Engine.Grasshopper
             {
                 return;
             }
-            Color bhColour = Query.RenderColour(args.Material.Diffuse);
             DisplayMaterial bhMaterial = Query.RenderMaterial(args.Material);
             try
             {

--- a/Grasshopper_Engine/Compute/RenderRhinoMesh.cs
+++ b/Grasshopper_Engine/Compute/RenderRhinoMesh.cs
@@ -1,0 +1,221 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using RHG = Rhino.Geometry;
+using Rhino.Display;
+using Grasshopper.Kernel;
+using System;
+using BH.oM.Reflection.Attributes;
+
+namespace BH.Engine.Grasshopper
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /**** Public Methods  - Interfaces              ****/
+        /***************************************************/
+
+        public static void IRenderRhinoMeshes(this object geometry, GH_PreviewMeshArgs args)
+        {
+            if (geometry == null)
+            {
+                return;
+            }
+            DisplayMaterial bhMaterial = Query.RenderMaterial(args.Material);
+
+            try
+            {
+                RenderRhinoMeshes(geometry as dynamic, args.Pipeline, bhMaterial);
+            }
+            catch (Exception) { }
+        }
+
+
+        /***************************************************/
+        /**** Public Methods  - Fallback                ****/
+        /***************************************************/
+
+        [NotImplemented]
+        public static void RenderRhinoMeshes(this object fallback, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            // fallback in case no method is found for the provided runtime type
+            return;
+        }
+
+
+        /***************************************************/
+        /**** Public Methods  - Vectors                 ****/
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.Point3d point, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            return;
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.Vector3d vector, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            return;
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.Plane plane, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            return;
+        }
+
+
+        /***************************************************/
+        /**** Public Methods  - Curves                  ****/
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.Arc arc, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            return;
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.ArcCurve arc, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            return;
+        }
+
+
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.Circle circle, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            return;
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.Curve curve, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            return;
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.Ellipse ellipse, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            return;
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.Line line, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            return;
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.LineCurve line, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            return;
+        }
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.NurbsCurve curve, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            return;
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.PolyCurve polycurve, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            return;
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.Polyline polyline, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            return;
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.PolylineCurve polyline, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            return;
+        }
+
+
+        /***************************************************/
+        /**** Public Methods  - Surfaces                ****/
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.Extrusion surface, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            pipeline.DrawBrepShaded(surface.ToBrep(), material);
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.NurbsSurface surface, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            pipeline.DrawBrepShaded(surface.ToBrep(), material);
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.Brep brep, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            pipeline.DrawBrepShaded(brep, material);
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.Surface surface, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            pipeline.DrawBrepShaded(surface.ToBrep(), material);
+        }
+
+
+        /***************************************************/
+        /**** Public Methods  - Mesh                    ****/
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.Mesh mesh, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            pipeline.DrawMeshShaded(mesh, material);
+        }
+
+
+        /***************************************************/
+        /**** Public Methods  - Miscellanea             ****/
+        /***************************************************/
+
+        public static void RenderRhinoMeshes(RHG.BoundingBox bbBox, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            pipeline.DrawBrepShaded(bbBox.ToBrep(), material);
+        }
+
+        /***************************************************/
+    }
+}

--- a/Grasshopper_Engine/Compute/RenderRhinoMesh.cs
+++ b/Grasshopper_Engine/Compute/RenderRhinoMesh.cs
@@ -25,6 +25,7 @@ using Rhino.Display;
 using Grasshopper.Kernel;
 using System;
 using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
 
 namespace BH.Engine.Grasshopper
 {
@@ -47,6 +48,16 @@ namespace BH.Engine.Grasshopper
                 RenderRhinoMeshes(geometry as dynamic, args.Pipeline, bhMaterial);
             }
             catch (Exception) { }
+        }
+
+        /***************************************************/
+
+        public static void IRenderRhinoMeshes(this List<object> geometry, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            foreach(object geo in geometry)
+            {
+                IRenderRhinoMeshes(geo as dynamic, pipeline, material);
+            }
         }
 
 

--- a/Grasshopper_Engine/Compute/RenderRhinoWires.cs
+++ b/Grasshopper_Engine/Compute/RenderRhinoWires.cs
@@ -1,0 +1,216 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using RHG = Rhino.Geometry;
+using Rhino.Display;
+using Grasshopper.Kernel;
+using System;
+using System.Drawing;
+using BH.oM.Reflection.Attributes;
+
+namespace BH.Engine.Grasshopper
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /**** Public Methods  - Interfaces              ****/
+        /***************************************************/
+
+        public static void IRenderRhinoWires(this object geometry, GH_PreviewWireArgs args)
+        {
+            if (geometry == null)
+            {
+                return;
+            }
+            Color bhColour = Query.RenderColour(args.Color);
+            try
+            {
+                RenderRhinoWires(geometry as dynamic, args.Pipeline, bhColour);
+            }
+            catch (Exception) { }
+        }
+
+
+        /***************************************************/
+        /**** Public Methods  - Fallback                ****/
+        /***************************************************/
+
+        [NotImplemented]
+        public static void RenderRhinoWires(this object fallback, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        {
+            // fallback in case no method is found for the provided runtime type
+            return;
+        }
+
+
+        /***************************************************/
+        /**** Public Methods  - Vectors                 ****/
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.Point point, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            return;
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.Vector3d vector, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            //args.Pipeline.DrawLineArrow(vector.ToRhino(), args.Color, args.Thickness, args.Thickness);
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.Plane plane, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            pipeline.DrawConstructionPlane(new Rhino.DocObjects.ConstructionPlane() { Plane = plane, ThickLineColor = bhColour, ThinLineColor = Color.Black, GridLineCount = 10 });
+        }
+
+
+        /***************************************************/
+        /**** Public Methods  - Curves                  ****/
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.Arc arc, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            pipeline.DrawArc(arc, bhColour, 2);
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.ArcCurve arc, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            pipeline.DrawArc(arc.Arc, bhColour, 2);
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.Circle circle, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            pipeline.DrawCircle(circle, bhColour, 2);
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.Curve curve, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            pipeline.DrawCurve(curve, bhColour, 2);
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.Ellipse ellipse, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            pipeline.DrawCurve(ellipse.ToNurbsCurve(), bhColour, 2);
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.Line line, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            pipeline.DrawLine(line, bhColour, 2);
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.LineCurve line, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            pipeline.DrawLine(line.Line, bhColour, 2);
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.NurbsCurve curve, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            pipeline.DrawCurve(curve, bhColour, 2);
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.PolyCurve polycurve, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            pipeline.DrawCurve(polycurve, bhColour, 2);
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.Polyline polyline, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            pipeline.DrawPolyline(polyline, bhColour, 2);
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.PolylineCurve polyline, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            RHG.Polyline poly;
+            if (polyline.TryGetPolyline(out poly))
+                pipeline.DrawPolyline(poly, bhColour, 2);
+        }
+
+
+        /***************************************************/
+        /**** Public Methods  - Surfaces                ****/
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.Extrusion surface, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            pipeline.DrawSurface(surface, bhColour, 2);
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.NurbsSurface surface, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            pipeline.DrawSurface(surface, bhColour, 2);
+        }
+
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.Brep brep, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            pipeline.DrawBrepWires(brep, bhColour, 0);
+        }
+
+
+        /***************************************************/
+        /**** Public Methods  - Mesh                    ****/
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.Mesh mesh, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            pipeline.DrawMeshWires(mesh, bhColour);
+        }
+
+
+        /***************************************************/
+        /**** Public Methods  - Miscellanea             ****/
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.BoundingBox bbBox, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            pipeline.DrawBox(bbBox, bhColour, 2);
+        }
+
+        /***************************************************/
+    }
+}

--- a/Grasshopper_Engine/Compute/RenderRhinoWires.cs
+++ b/Grasshopper_Engine/Compute/RenderRhinoWires.cs
@@ -26,6 +26,7 @@ using Grasshopper.Kernel;
 using System;
 using System.Drawing;
 using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
 
 namespace BH.Engine.Grasshopper
 {
@@ -49,13 +50,23 @@ namespace BH.Engine.Grasshopper
             catch (Exception) { }
         }
 
+        /***************************************************/
+
+        public static void RenderRhinoWires(this List<object> geometry, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
+        {
+            foreach(object geo in geometry)
+            {
+                RenderRhinoWires(geo as dynamic, pipeline, bhColour);
+            }
+        }
+
 
         /***************************************************/
         /**** Public Methods  - Fallback                ****/
         /***************************************************/
 
         [NotImplemented]
-        public static void RenderRhinoWires(this object fallback, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
+        public static void RenderRhinoWires(this object fallback, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
         {
             // fallback in case no method is found for the provided runtime type
             return;

--- a/Grasshopper_Engine/Grasshopper_Engine.csproj
+++ b/Grasshopper_Engine/Grasshopper_Engine.csproj
@@ -62,6 +62,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>
     </Reference>
+    <Reference Include="Reflection_oM, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\BHoM\Build\Reflection_oM.dll</HintPath>
+    </Reference>
     <Reference Include="Rhinoceros_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Rhinoceros_Toolkit\Build\Rhinoceros_Engine.dll</HintPath>
@@ -92,6 +96,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Compute\RenderMeshes.cs" />
+    <Compile Include="Compute\RenderRhinoMesh.cs" />
+    <Compile Include="Compute\RenderRhinoWires.cs" />
     <Compile Include="Compute\RenderWires.cs" />
     <Compile Include="Convert\ToGoo.cs" />
     <Compile Include="Convert\FromGoo.cs" />

--- a/Grasshopper_Engine/Objects/Types/GH_BHoMObject.cs
+++ b/Grasshopper_Engine/Objects/Types/GH_BHoMObject.cs
@@ -52,6 +52,19 @@ namespace BH.Engine.Grasshopper.Objects
 
         public virtual Rhino.Geometry.BoundingBox Boundingbox { get { return Bounds(); } }
 
+        public override object Value
+        {
+            get
+            {
+                return base.Value;
+            }
+            set
+            {
+                base.Value = value;
+                SetGeometry();
+            }
+        }
+
 
         /*******************************************/
         /**** Constructors                      ****/
@@ -61,10 +74,7 @@ namespace BH.Engine.Grasshopper.Objects
 
         /***************************************************/
 
-        public GH_BHoMObject(BHoMObject val) : base(val)
-        {
-            SetGeometry();
-        }
+        public GH_BHoMObject(BHoMObject val) : base(val) { }
 
 
         /*******************************************/
@@ -95,13 +105,7 @@ namespace BH.Engine.Grasshopper.Objects
             if (source.GetType().Namespace.StartsWith("Rhino.Geometry"))
                 source = BH.Engine.Rhinoceros.Convert.ToBHoM(source as dynamic);
 
-            if (base.CastFrom(source))
-            {
-                SetGeometry();
-                return true;
-            }
-
-            return false;
+            return base.CastFrom(source);
         }
 
         /***************************************************/

--- a/Grasshopper_Engine/Objects/Types/GH_BHoMObject.cs
+++ b/Grasshopper_Engine/Objects/Types/GH_BHoMObject.cs
@@ -141,14 +141,14 @@ namespace BH.Engine.Grasshopper.Objects
 
         public virtual void DrawViewportMeshes(GH_PreviewMeshArgs args)
         {
-            Engine.Grasshopper.Compute.IRenderMeshes(m_Geometry, args);
+            Engine.Grasshopper.Compute.IRenderRhinoMeshes(m_RhinoGeometry, args);
         }
 
         /***************************************************/
 
         public virtual void DrawViewportWires(GH_PreviewWireArgs args)
         {
-            Engine.Grasshopper.Compute.IRenderWires(m_Geometry, args);
+            Engine.Grasshopper.Compute.IRenderRhinoWires(m_RhinoGeometry, args);
         }
 
 
@@ -165,11 +165,13 @@ namespace BH.Engine.Grasshopper.Objects
             else if (Value is BHoMObject)
             {
                 m_Geometry = ((BHoMObject)Value).IGeometry();
+                m_RhinoGeometry = m_Geometry.IToRhino();
                 return true;
             }
             else if (Value is IGeometry)
             {
                 m_Geometry = Value as IGeometry;
+                m_RhinoGeometry = m_Geometry.IToRhino();
                 return true;
             }
             else
@@ -208,6 +210,8 @@ namespace BH.Engine.Grasshopper.Objects
         /***************************************************/
 
         private IGeometry m_Geometry = null;
+
+        private object m_RhinoGeometry = null;
 
         /***************************************************/
     }

--- a/Grasshopper_Engine/Objects/Types/GH_IBHoMGeometry.cs
+++ b/Grasshopper_Engine/Objects/Types/GH_IBHoMGeometry.cs
@@ -390,7 +390,9 @@ namespace BH.Engine.Grasshopper.Objects
 
         private bool SetRhinoValue()
         {
-            if (BH.Engine.Rhinoceros.Query.IsRhinoEquivalent(m_Value.GetType()))
+            if (m_Value == null)
+                return true;
+            else if (BH.Engine.Rhinoceros.Query.IsRhinoEquivalent(m_Value.GetType()))
                 m_RhinoValue = m_Value.IToRhino();
             return true;
         }

--- a/Grasshopper_Engine/Objects/Types/GH_IBHoMGeometry.cs
+++ b/Grasshopper_Engine/Objects/Types/GH_IBHoMGeometry.cs
@@ -82,7 +82,6 @@ namespace BH.Engine.Grasshopper.Objects
         public GH_IBHoMGeometry(object bh)
         {
             Value = bh;
-            SetRhinoValue();
         }
 
 

--- a/Grasshopper_Engine/Objects/Types/GH_IBHoMGeometry.cs
+++ b/Grasshopper_Engine/Objects/Types/GH_IBHoMGeometry.cs
@@ -335,7 +335,6 @@ namespace BH.Engine.Grasshopper.Objects
 
         public void DrawViewportMeshes(GH_PreviewMeshArgs args)
         {
-            Engine.Grasshopper.Compute.IRenderRhinoMeshes(Value, args);
             Engine.Grasshopper.Compute.IRenderRhinoMeshes(m_RhinoValue, args);
         }
 
@@ -343,7 +342,6 @@ namespace BH.Engine.Grasshopper.Objects
 
         public void DrawViewportWires(GH_PreviewWireArgs args)
         {
-            Engine.Grasshopper.Compute.IRenderRhinoWires(Value, args);
             Engine.Grasshopper.Compute.IRenderRhinoWires(m_RhinoValue, args);
         }
 

--- a/Grasshopper_Engine/Objects/Types/GH_IBHoMGeometry.cs
+++ b/Grasshopper_Engine/Objects/Types/GH_IBHoMGeometry.cs
@@ -352,15 +352,10 @@ namespace BH.Engine.Grasshopper.Objects
 
         public bool BakeGeometry(RhinoDoc doc, ObjectAttributes att, out Guid obj_guid)
         {
-            if (m_Value != null)
+            if (m_RhinoValue != null)
             {
-                Rhino.Geometry.GeometryBase geometry = m_Value.IToRhino() as Rhino.Geometry.GeometryBase;
-                if (geometry != null)
-                {
-                    obj_guid = doc.Objects.Add(geometry, att);
-                    return true;
-                }
-
+                obj_guid = doc.Objects.Add(GH_Convert.ToGeometryBase(m_RhinoValue), att);
+                return true;
             }
 
             obj_guid = Guid.Empty;

--- a/Grasshopper_Engine/Objects/Types/GH_IBHoMGeometry.cs
+++ b/Grasshopper_Engine/Objects/Types/GH_IBHoMGeometry.cs
@@ -336,6 +336,7 @@ namespace BH.Engine.Grasshopper.Objects
         public void DrawViewportMeshes(GH_PreviewMeshArgs args)
         {
             Engine.Grasshopper.Compute.IRenderRhinoMeshes(Value, args);
+            Engine.Grasshopper.Compute.IRenderRhinoMeshes(m_RhinoValue, args);
         }
 
         /***************************************************/
@@ -343,6 +344,7 @@ namespace BH.Engine.Grasshopper.Objects
         public void DrawViewportWires(GH_PreviewWireArgs args)
         {
             Engine.Grasshopper.Compute.IRenderRhinoWires(Value, args);
+            Engine.Grasshopper.Compute.IRenderRhinoWires(m_RhinoValue, args);
         }
 
 

--- a/Grasshopper_Engine/Objects/Types/GH_IBHoMGeometry.cs
+++ b/Grasshopper_Engine/Objects/Types/GH_IBHoMGeometry.cs
@@ -50,14 +50,14 @@ namespace BH.Engine.Grasshopper.Objects
 
         public override Rhino.Geometry.BoundingBox Boundingbox { get { return Bounds(); } }
 
-        public override object Value
+        public override object Value // This is a Rhino.Geometry object
         {
             get
             {
                 if (m_Value == null)
                     return null;
-                else if (BH.Engine.Rhinoceros.Query.IsRhinoEquivalent(m_Value.GetType()))
-                    return m_Value.IToRhino();
+                else if (m_RhinoValue != null)
+                    return m_RhinoValue;
                 else
                     return m_Value;
             }
@@ -82,6 +82,7 @@ namespace BH.Engine.Grasshopper.Objects
         public GH_IBHoMGeometry(object bh)
         {
             Value = bh;
+            SetRhinoValue();
         }
 
 
@@ -230,6 +231,7 @@ namespace BH.Engine.Grasshopper.Objects
             else
                 m_Value = GH_Convert.ToGeometryBase(source).IToBHoM();
 
+            SetRhinoValue();
             return true;
         }
 
@@ -333,14 +335,14 @@ namespace BH.Engine.Grasshopper.Objects
 
         public void DrawViewportMeshes(GH_PreviewMeshArgs args)
         {
-            Engine.Grasshopper.Compute.IRenderMeshes(m_Value, args);
+            Engine.Grasshopper.Compute.IRenderRhinoMeshes(Value, args);
         }
 
         /***************************************************/
 
         public void DrawViewportWires(GH_PreviewWireArgs args)
         {
-            Engine.Grasshopper.Compute.IRenderWires(m_Value, args);
+            Engine.Grasshopper.Compute.IRenderRhinoWires(Value, args);
         }
 
 
@@ -390,11 +392,21 @@ namespace BH.Engine.Grasshopper.Objects
         }
 
         /***************************************************/
+
+        private bool SetRhinoValue()
+        {
+            if (BH.Engine.Rhinoceros.Query.IsRhinoEquivalent(m_Value.GetType()))
+                m_RhinoValue = m_Value.IToRhino();
+            return true;
+        }
+
+        /***************************************************/
         /**** Private Fields                            ****/
         /***************************************************/
 
         private IGeometry m_Value = null;
 
+        private object m_RhinoValue = null;
 
         /***************************************************/
     }

--- a/Grasshopper_Engine/Objects/Types/GH_IBHoMGeometry.cs
+++ b/Grasshopper_Engine/Objects/Types/GH_IBHoMGeometry.cs
@@ -50,7 +50,7 @@ namespace BH.Engine.Grasshopper.Objects
 
         public override Rhino.Geometry.BoundingBox Boundingbox { get { return Bounds(); } }
 
-        public override object Value // This is a Rhino.Geometry object
+        public override object Value // This is a Rhino.Geometry object if possibile, a BH.oM.Geometry otherwise
         {
             get
             {

--- a/Grasshopper_Engine/Objects/Types/GH_IObject.cs
+++ b/Grasshopper_Engine/Objects/Types/GH_IObject.cs
@@ -107,7 +107,6 @@ namespace BH.Engine.Grasshopper.Objects
 
             if (base.CastFrom(source))
             {
-                SetGeometry();
                 return true;
             }
 

--- a/Grasshopper_Engine/Objects/Types/GH_IObject.cs
+++ b/Grasshopper_Engine/Objects/Types/GH_IObject.cs
@@ -52,6 +52,19 @@ namespace BH.Engine.Grasshopper.Objects
 
         public virtual Rhino.Geometry.BoundingBox Boundingbox { get { return Bounds(); } }
 
+        public override object Value
+        {
+            get
+            {
+                return base.Value;
+            }
+            set
+            {
+                base.Value = value;
+                SetGeometry();
+            }
+        }
+
 
         /*******************************************/
         /**** Constructors                      ****/
@@ -61,10 +74,7 @@ namespace BH.Engine.Grasshopper.Objects
 
         /***************************************************/
 
-        public GH_IObject(IObject val) : base(val)
-        {
-            SetGeometry();
-        }
+        public GH_IObject(IObject val) : base(val) { }
 
 
         /*******************************************/

--- a/Grasshopper_Engine/Objects/Types/GH_IObject.cs
+++ b/Grasshopper_Engine/Objects/Types/GH_IObject.cs
@@ -148,7 +148,7 @@ namespace BH.Engine.Grasshopper.Objects
 
         public virtual void DrawViewportWires(GH_PreviewWireArgs args)
         {
-            Engine.Grasshopper.Compute.IRenderRhinoWires(m_Geometry, args);
+            Engine.Grasshopper.Compute.IRenderRhinoWires(m_RhinoGeometry, args);
         }
 
 

--- a/Grasshopper_Engine/Query/RenderColor.cs
+++ b/Grasshopper_Engine/Query/RenderColor.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -33,28 +33,19 @@ namespace BH.Engine.Grasshopper
 
         public static Color RenderColour(Color ghColour)
         {
-            if (m_RenderColour != default(Color))
-            {
-                return m_RenderColour;
-            }
-
             Color pColour = GH.Instances.ActiveCanvas.Document.PreviewColour;
             if (ghColour.R == pColour.R & // If the color sent by PreviewArgs is the default object PreviewColour
                 ghColour.G == pColour.G &
                 ghColour.B == pColour.B) // Excluding Alpha channel from comparison
             {
-                m_RenderColour = Color.FromArgb(80, 255, 41, 105);
-                return m_RenderColour;
+                return Color.FromArgb(80, 255, 41, 105);
             }
             else
             {
-                m_RenderColour = ghColour;
-                return m_RenderColour;
+                return ghColour;
             }
         }
 
         /***************************************************/
-
-        private static Color m_RenderColour;
     }
 }

--- a/Grasshopper_Engine/Query/RenderColor.cs
+++ b/Grasshopper_Engine/Query/RenderColor.cs
@@ -33,19 +33,28 @@ namespace BH.Engine.Grasshopper
 
         public static Color RenderColour(Color ghColour)
         {
+            if (m_RenderColour != default(Color))
+            {
+                return m_RenderColour;
+            }
+
             Color pColour = GH.Instances.ActiveCanvas.Document.PreviewColour;
             if (ghColour.R == pColour.R & // If the color sent by PreviewArgs is the default object PreviewColour
                 ghColour.G == pColour.G &
                 ghColour.B == pColour.B) // Excluding Alpha channel from comparison
             {
-                return Color.FromArgb(80, 255, 41, 105);
+                m_RenderColour = Color.FromArgb(80, 255, 41, 105);
+                return m_RenderColour;
             }
             else
             {
-                return ghColour;
+                m_RenderColour = ghColour;
+                return m_RenderColour;
             }
         }
 
         /***************************************************/
+
+        private static Color m_RenderColour;
     }
 }

--- a/Grasshopper_Engine/Query/RenderMaterial.cs
+++ b/Grasshopper_Engine/Query/RenderMaterial.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -34,29 +34,20 @@ namespace BH.Engine.Grasshopper
 
         public static DisplayMaterial RenderMaterial(DisplayMaterial material)
         {
-            if (m_RenderMaterial != null)
-            {
-                return m_RenderMaterial;
-            }
-
             Color pColour = GH.Instances.ActiveCanvas.Document.PreviewColour;
             Color ghColour = material.Diffuse;
             if (ghColour.R == pColour.R & // If the color sent by PreviewArgs is the default object PreviewColour
                 ghColour.G == pColour.G &
                 ghColour.B == pColour.B) // Excluding Alpha channel from comparison
             {
-                m_RenderMaterial = new DisplayMaterial(Color.FromArgb(255, 255, 41, 105), 0.6);
-                return m_RenderMaterial;
+                return new DisplayMaterial(Color.FromArgb(255, 255, 41, 105), 0.6);
             }
             else
             {
-                m_RenderMaterial = material;
-                return m_RenderMaterial;
+                return material;
             }
         }
 
         /***************************************************/
-
-        private static DisplayMaterial m_RenderMaterial;
     }
 }

--- a/Grasshopper_Engine/Query/RenderMaterial.cs
+++ b/Grasshopper_Engine/Query/RenderMaterial.cs
@@ -34,20 +34,29 @@ namespace BH.Engine.Grasshopper
 
         public static DisplayMaterial RenderMaterial(DisplayMaterial material)
         {
+            if (m_RenderMaterial != null)
+            {
+                return m_RenderMaterial;
+            }
+
             Color pColour = GH.Instances.ActiveCanvas.Document.PreviewColour;
             Color ghColour = material.Diffuse;
             if (ghColour.R == pColour.R & // If the color sent by PreviewArgs is the default object PreviewColour
                 ghColour.G == pColour.G &
                 ghColour.B == pColour.B) // Excluding Alpha channel from comparison
             {
-                return new DisplayMaterial(Color.FromArgb(255, 255, 41, 105), 0.6);
+                m_RenderMaterial = new DisplayMaterial(Color.FromArgb(255, 255, 41, 105), 0.6);
+                return m_RenderMaterial;
             }
             else
             {
-                return material;
+                m_RenderMaterial = material;
+                return m_RenderMaterial;
             }
         }
 
         /***************************************************/
+
+        private static DisplayMaterial m_RenderMaterial;
     }
 }

--- a/Grasshopper_UI/2.1/Templates/DataAccessor_GH.cs
+++ b/Grasshopper_UI/2.1/Templates/DataAccessor_GH.cs
@@ -126,7 +126,7 @@ namespace BH.UI.Grasshopper.Templates
             }
             else if (typeof(IGeometry).IsAssignableFrom(data.GetType()))
             {
-                object result = BH.Engine.Grasshopper.Convert.ToRhino(data);
+                object result = data;// BH.Engine.Grasshopper.Convert.ToRhino(data);
                 if (result is IEnumerable)
                     return GH_Accessor.SetDataList(index, result as IEnumerable);
                 else
@@ -141,7 +141,7 @@ namespace BH.UI.Grasshopper.Templates
         public override bool SetDataList<T>(int index, IEnumerable<T> data)
         {
             if (data != null && typeof(IGeometry).IsAssignableFrom(typeof(T)))
-                return GH_Accessor.SetDataList(index, ((IEnumerable<T>)data).Select(x => BH.Engine.Grasshopper.Convert.ToRhino(x)));
+                return GH_Accessor.SetDataList(index, ((IEnumerable<T>)data));//.Select(x => BH.Engine.Grasshopper.Convert.ToRhino(x)));
             else
                 return GH_Accessor.SetDataList(index, (IEnumerable<T>)data);
         }
@@ -158,7 +158,7 @@ namespace BH.UI.Grasshopper.Templates
                 root = Component.Params.Input.FindAll(p => p.Access == GH_ParamAccess.tree).FirstOrDefault() ?? Component.Params.Input.First();
 
             if (typeof(IGeometry).IsAssignableFrom(typeof(T)))
-                return GH_Accessor.SetDataTree(index, BH.Engine.Grasshopper.Create.DataTree(((IEnumerable<IEnumerable<T>>)data).Select(v => v.Select(x => (BH.Engine.Grasshopper.Convert.ToRhino(x)))).ToList(), GH_Accessor.Iteration, root.VolatileData.Paths));
+                return GH_Accessor.SetDataTree(index, BH.Engine.Grasshopper.Create.DataTree(((IEnumerable<IEnumerable<T>>)data).Select(v => v.Select(x => x/*(BH.Engine.Grasshopper.Convert.ToRhino(x))*/)).ToList(), GH_Accessor.Iteration, root.VolatileData.Paths));
             else
                 return GH_Accessor.SetDataTree(index, BH.Engine.Grasshopper.Create.DataTree(data.ToList(), GH_Accessor.Iteration, root.VolatileData.Paths));
         }

--- a/Grasshopper_UI/2.1/Templates/DataAccessor_GH.cs
+++ b/Grasshopper_UI/2.1/Templates/DataAccessor_GH.cs
@@ -120,30 +120,14 @@ namespace BH.UI.Grasshopper.Templates
 
         public override bool SetDataItem<T>(int index, T data)
         {
-            if (data == null)
-            {
-                return GH_Accessor.SetData(index, data);
-            }
-            else if (typeof(IGeometry).IsAssignableFrom(data.GetType()))
-            {
-                object result = data;// BH.Engine.Grasshopper.Convert.ToRhino(data);
-                if (result is IEnumerable)
-                    return GH_Accessor.SetDataList(index, result as IEnumerable);
-                else
-                    return GH_Accessor.SetData(index, result);
-            }
-            else
-                return GH_Accessor.SetData(index, data);
+            return GH_Accessor.SetData(index, data);
         }
 
         /*************************************/
 
         public override bool SetDataList<T>(int index, IEnumerable<T> data)
         {
-            if (data != null && typeof(IGeometry).IsAssignableFrom(typeof(T)))
-                return GH_Accessor.SetDataList(index, ((IEnumerable<T>)data));//.Select(x => BH.Engine.Grasshopper.Convert.ToRhino(x)));
-            else
-                return GH_Accessor.SetDataList(index, (IEnumerable<T>)data);
+            return GH_Accessor.SetDataList(index, (IEnumerable<T>)data);
         }
 
         /*************************************/
@@ -157,10 +141,7 @@ namespace BH.UI.Grasshopper.Templates
             else
                 root = Component.Params.Input.FindAll(p => p.Access == GH_ParamAccess.tree).FirstOrDefault() ?? Component.Params.Input.First();
 
-            if (typeof(IGeometry).IsAssignableFrom(typeof(T)))
-                return GH_Accessor.SetDataTree(index, BH.Engine.Grasshopper.Create.DataTree(((IEnumerable<IEnumerable<T>>)data).Select(v => v.Select(x => x/*(BH.Engine.Grasshopper.Convert.ToRhino(x))*/)).ToList(), GH_Accessor.Iteration, root.VolatileData.Paths));
-            else
-                return GH_Accessor.SetDataTree(index, BH.Engine.Grasshopper.Create.DataTree(data.ToList(), GH_Accessor.Iteration, root.VolatileData.Paths));
+            return GH_Accessor.SetDataTree(index, BH.Engine.Grasshopper.Create.DataTree(data.ToList(), GH_Accessor.Iteration, root.VolatileData.Paths));
         }
 
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #340 

<!-- Add short description of what has been fixed -->
The rendering methods are now converting back and forth Rhino geometries at every display frame. This causes a big lag when the `Convert` method is computationally expensive.

The conversion is happening in two places:
- The `RenderWires` and `RenderMeshes` methods
- The `get_Value` method of the `BH.Engine.Grasshopper.Objects.*`

This PR is proposing to store the converted rhino geometry and use that one to render and exchange `Value`s.

This is actually modifying the way we pass the values between components, so before merging this, **please, try to break it!**

### Test files
<!-- Link to test files to validate the proposed changes -->
My advice is to try this file using the master and using this branch to check the performance improvement. Then, try to break the code in this branch only.
https://burohappold.sharepoint.com/:f:/s/BHoM/Er0Mwo6YQspNngsbElNVlwABs6T5ejBr_yKnUJxR3ipZ6g?e=dVSLm8
### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
@adecler FYI