### PR TITLE
Update post build events to centralise assemblies location

### DIFF
--- a/Grasshopper_UI/Grasshopper_UI.csproj
+++ b/Grasshopper_UI/Grasshopper_UI.csproj
@@ -365,9 +365,14 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>call "$(TargetDir)UI_PostBuild.exe" ..\..\ "C:\Users\$(Username)\AppData\Roaming\Grasshopper\Libraries\BHoM"
+    <PostBuildEvent>call "$(TargetDir)UI_PostBuild.exe" ..\..\ "$(AppData)\BHoM\Assemblies"
+Copy /Y "$(TargetName).dll" "$(AppData)\BHoM\Assemblies\$(TargetName).gha"
 
-Copy /Y "$(TargetName).dll" "C:\Users\$(Username)\AppData\Roaming\Grasshopper\Libraries\BHoM\$(TargetName).gha"</PostBuildEvent>
+IF EXIST $(AppData)\Grasshopper\Libraries\BHoM (
+RD /S /Q $(AppData)\Grasshopper\Libraries\BHoM
+)
+
+echo $(AppData)\BHoM\Assemblies\$(TargetName).gha &gt; $(AppData)\Grasshopper\Libraries\$(TargetName).ghlink</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <FallbackCulture>en-US</FallbackCulture>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #343 
<!-- Add short description of what has been fixed -->
This PR is switching to the [`.ghlink` logic](https://www.grasshopper3d.com/forum/topics/sdk-changes-and-new-features-in-grasshopper-0-9-0050?commentId=2985220%3AComment%3A841407) to load assemblies in Grasshopper.
Achieved though new post build events. 

Note that the post-build events are clearing your %AppData%\Grasshopper\Libraries\BHoM folder and deleting it, in case it exists.

### Test files
<!-- Link to test files to validate the proposed changes -->
Two tests are required: compiling from source and installing through latest BHoM_Installer