### PR TITLE
Casting to RHG.Surface for Polysurface ToRhino

### DIFF
--- a/Grasshopper_Engine/Compute/RenderMeshes.cs
+++ b/Grasshopper_Engine/Compute/RenderMeshes.cs
@@ -185,7 +185,7 @@ namespace BH.Engine.Grasshopper
             List<BHG.ISurface> surfaces = polySurface.Surfaces;
             for (int i = 0; i < surfaces.Count; i++)
             {
-                pipeline.DrawBrepShaded(RHG.Brep.CreateFromSurface(surfaces[i].IToRhino()), material);
+                pipeline.DrawBrepShaded(RHG.Brep.CreateFromSurface((RHG.Surface)surfaces[i].IToRhino()), material);
             }
         }
 

--- a/Grasshopper_Engine/Compute/RenderWires.cs
+++ b/Grasshopper_Engine/Compute/RenderWires.cs
@@ -178,7 +178,7 @@ namespace BH.Engine.Grasshopper
 
         public static void RenderWires(BHG.PolySurface polySurface, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
         {
-            polySurface.Surfaces.ForEach(srf => pipeline.DrawSurface(srf.IToRhino(), bhColour, 2));
+            polySurface.Surfaces.ForEach(srf => pipeline.DrawSurface((RHG.Surface)srf.IToRhino(), bhColour, 2));
         }
 
 

--- a/Grasshopper_UI/2.0/NonComponents/Render/RenderBHoMGeometry.cs
+++ b/Grasshopper_UI/2.0/NonComponents/Render/RenderBHoMGeometry.cs
@@ -158,7 +158,7 @@ namespace BH.UI.Grasshopper
 
         public static void RenderBHoMGeometry(BHG.PolySurface polySurface, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
         {
-            polySurface.Surfaces.ForEach(srf => pipeline.DrawSurface(srf.IToRhino(), bhColour, 1));
+            polySurface.Surfaces.ForEach(srf => pipeline.DrawSurface((RHG.Surface)srf.IToRhino(), bhColour, 1));
         }
 
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
This is to be tested in conjunction with https://github.com/BHoM/Rhinoceros_Toolkit/pull/89

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #345
As a result of issue in Rhinoceros_Toolkit here: https://github.com/BHoM/Rhinoceros_Toolkit/issues/85

<!-- Add short description of what has been fixed -->
Have added a simple cast to `RHG.Surface` as the called method is now needing to return the abstract `IGeometryBase`

### Test files
<!-- Link to test files to validate the proposed changes -->
Can be tested using these also:

[Test file for new Solid Object Converts](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02_Current%2F12_Scripts%2F01_Test%20Scripts%2FRhinoceros_Toolkit%2FRhinoceros_Toolkit-Issue86-87-SolidConverts&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)


[Test file for PolySurface to Brep fix](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02_Current%2F12_Scripts%2F01_Test%20Scripts%2FRhinoceros_Toolkit%2FRhinoceros_Toolkit-Issue85-PolySurface%20to%20Rhino%2EBRep%20Fail)

