### PR TITLE
Add the OLD label on deprecated methods

### DIFF
--- a/Grasshopper_UI/2.1/Templates/CallerComponent.cs
+++ b/Grasshopper_UI/2.1/Templates/CallerComponent.cs
@@ -33,6 +33,7 @@ using Grasshopper.Kernel.Parameters;
 using BH.UI.Grasshopper.Parameters;
 using BH.Engine.Reflection;
 using BH.oM.Geometry;
+using System.Reflection;
 
 namespace BH.UI.Grasshopper.Templates
 {
@@ -51,6 +52,8 @@ namespace BH.UI.Grasshopper.Templates
         public override Guid ComponentGuid { get { return Caller.Id; } }
 
         public override GH_Exposure Exposure { get { return (GH_Exposure)Math.Pow(2, Caller.GroupIndex); } }
+
+        public override bool Obsolete => this.IsObsolete();
 
 
         /*******************************************/
@@ -109,6 +112,16 @@ namespace BH.UI.Grasshopper.Templates
             {
                 BH.Engine.Reflection.Compute.IOpenHelpPage(Caller.SelectedItem);
             }
+        }
+
+        /*******************************************/
+
+        public virtual bool IsObsolete()
+        {
+            if (this.Caller.SelectedItem == null)
+                return false;
+
+            return this.Caller.SelectedItem.IIsDeprecated();
         }
 
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on https://github.com/BHoM/BHoM_Engine/pull/986
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #330
<!-- Add short description of what has been fixed -->
Deprecated methods are not correctly labelled as OLD in grasshopper. 
This pr checks the deprecated attribute of the method and adds the old label on it.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/Efx3saIU5pZDrXrxScSCYlAB24_LjFZWyPha5DGjCPE2Xg?e=pWAapR

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->