### PR TITLE
Grasshopper_Toolkit: Issue 384 - Add hints and tree access to property value of SetProperty

### DIFF
--- a/Grasshopper_Engine/Query/Type.cs
+++ b/Grasshopper_Engine/Query/Type.cs
@@ -44,8 +44,8 @@ namespace BH.Engine.Grasshopper
             if (param is Param_ScriptVariable)
                 return Type(((Param_ScriptVariable)param).TypeHint, param.Access);
 
-            else if (caller != null && caller is CreateCustomCaller)
-                return ((CreateCustomCaller)caller).GetParam(param.NickName).DataType;
+            else if (caller != null)
+                return (caller.InputParams.Find(x => x.Name == param.NickName))?.DataType;
 
             else
                 return param.Type;
@@ -56,7 +56,7 @@ namespace BH.Engine.Grasshopper
         public static Type Type(this IGH_TypeHint hint, GH_ParamAccess access)
         {
             if (hint == null)
-                return typeof(object);
+                return Type<object>(access);
 
             switch (hint.TypeName)
             {

--- a/Grasshopper_UI/2.1/Components/Engine/Explode.cs
+++ b/Grasshopper_UI/2.1/Components/Engine/Explode.cs
@@ -58,7 +58,7 @@ namespace BH.UI.Grasshopper.Components
 
         /*******************************************/
 
-        public void OnGrasshopperUpdates(object sender = null, object e = null)
+        public override void OnGrasshopperUpdates(object sender = null, GH_ParamServerEventArgs e = null)
         {
             // Update the output params based on input data
             Params.Input[0].CollectData();

--- a/Grasshopper_UI/2.1/Components/Engine/SetProperty.cs
+++ b/Grasshopper_UI/2.1/Components/Engine/SetProperty.cs
@@ -20,13 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
 using Grasshopper.Kernel;
-using BH.oM.Base;
-using BH.UI.Grasshopper.Base;
 using BH.UI.Grasshopper.Templates;
 using BH.UI.Templates;
 using BH.UI.Components;
+using Grasshopper.Kernel.Parameters;
 
 namespace BH.UI.Grasshopper.Components
 {
@@ -38,6 +36,25 @@ namespace BH.UI.Grasshopper.Components
 
         public override Caller Caller { get; } = new SetPropertyCaller();
 
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public SetPropertyComponent() : base()
+        {
+            this.Params.ParameterChanged += OnGrasshopperUpdates;
+            if (Params.Input.Count > 2)
+            {
+                Param_ScriptVariable paramScript = Params.Input[2] as Param_ScriptVariable;
+                if (paramScript != null)
+                {
+                    paramScript.ShowHints = true;
+                    paramScript.Hints = Engine.Grasshopper.Query.AvailableHints;
+                    paramScript.AllowTreeAccess = true;
+                }
+            }
+        }
 
         /*******************************************/
     }

--- a/Grasshopper_UI/2.1/Components/UI/UpdateVersion.cs
+++ b/Grasshopper_UI/2.1/Components/UI/UpdateVersion.cs
@@ -389,7 +389,7 @@ namespace BH.UI.Grasshopper.Base
         {
             CreateCustomComponent newComp = new CreateCustomComponent();
             CreateCustomCaller caller = newComp.Caller as CreateCustomCaller;
-            caller.SetInputs(component.Params.Input.Select(x => x.NickName).ToList());
+            caller.SetInputParams(component.Params.Input.Select(x => x.NickName).ToList());
             newComp.OnItemSelected();
 
             return SwapComponent(doc, component, newComp, component.SelectedType);

--- a/Grasshopper_UI/2.1/Components/UI/UpdateVersion.cs
+++ b/Grasshopper_UI/2.1/Components/UI/UpdateVersion.cs
@@ -389,7 +389,7 @@ namespace BH.UI.Grasshopper.Base
         {
             CreateCustomComponent newComp = new CreateCustomComponent();
             CreateCustomCaller caller = newComp.Caller as CreateCustomCaller;
-            caller.SetInputParams(component.Params.Input.Select(x => x.NickName).ToList());
+            caller.SetInputs(component.Params.Input.Select(x => x.NickName).ToList());
             newComp.OnItemSelected();
 
             return SwapComponent(doc, component, newComp, component.SelectedType);

--- a/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
+++ b/Grasshopper_UI/2.1/Components/oM/CreateCustom.cs
@@ -27,7 +27,6 @@ using BH.UI.Components;
 using Grasshopper.Kernel.Parameters;
 using Grasshopper.Kernel.Parameters.Hints;
 using BH.Engine.Grasshopper;
-using System.Linq;
 
 namespace BH.UI.Grasshopper.Components
 {
@@ -47,38 +46,6 @@ namespace BH.UI.Grasshopper.Components
         public CreateCustomComponent() : base()
         {
             this.Params.ParameterChanged += OnGrasshopperUpdates;
-        }
-
-
-        /*******************************************/
-        /**** Public Methods                    ****/
-        /*******************************************/
-
-        public void OnGrasshopperUpdates(object sender, GH_ParamServerEventArgs e)
-        {
-            if (sender == null)
-                return;
-
-            if (e == null || e.Parameter == null || e.ParameterIndex == -1 || Caller?.InputParams.Count - 1 < e.ParameterIndex)
-                return;
-
-            CreateCustomCaller caller = Caller as CreateCustomCaller;
-            if (caller == null)
-                return;
-
-            // We recompute only if there is no other scheduled solution running or the update does not come from an explode, which will cause a crash
-            // we also avoid recomputing if we just reconnected the same wire
-            bool recompute = this.Phase == GH_SolutionPhase.Computed
-                             && !e.Parameter.Sources.Any(p => p.Attributes.GetTopLevel.DocObject is ExplodeComponent)
-                             && e.Parameter.NickName != caller.InputParams[e.ParameterIndex].Name;
-            
-            // Updating Caller.InputParams based on the new Grasshopper parameter just received
-            // We update the InputParams with the new type or name
-            caller.UpdateInput(e.ParameterIndex, e.Parameter.NickName, e.Parameter.Type(caller));
-
-            // and expire because of the changes made
-            ExpireSolution(recompute);
-            return;
         }
 
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

Depends on: https://github.com/BHoM/BHoM_UI/pull/116
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #384 
Closes #350 
Opens #372 
<!-- Add short description of what has been fixed -->
I left some messages on the code itself to make it easier for the reviewers to track the changes.
To summarise:
- The `SetPropertyComponent` requires the method `CreateCustom.OnGrasshopperUpdates` exactly as it is. The method has now been migrated to the `CallerComponent` exactly as it is. The `Explode` component also overwrites that method. 
- The `SetProperty` now contains `Hints` and `TreeAccess` exactly like the `CreateCustomComponent` - also works with the same logic.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/Eo5nuf2lHsJKolP8-gDFP7kBavPMdolrSTc2pnjhX5ebxw?e=Yg8K8l