### PR TITLE
Grasshopper_Toolkit: 386 - FixFromGooForGH_Surface

### DIFF
--- a/Grasshopper_Engine/Convert/FromGoo.cs
+++ b/Grasshopper_Engine/Convert/FromGoo.cs
@@ -70,12 +70,12 @@ namespace BH.Engine.Grasshopper
 
         /*************************************/
 
-        public static T FromGoo<T>(this GH_Surface goo, IGH_TypeHint hint = null) where T : Surface
+        public static T FromGoo<T>(this GH_Surface goo, IGH_TypeHint hint = null)
         {
             Brep brep = goo.ScriptVariable() as Brep;
             if (brep.IsSurface)
-                return (T)(brep.Faces[0] as dynamic);
-            return null;
+                return (T)(brep.Faces[0].UnderlyingSurface() as dynamic);
+            return default(T);
         }
     }
 }

--- a/Grasshopper_Engine/Convert/FromGoo.cs
+++ b/Grasshopper_Engine/Convert/FromGoo.cs
@@ -23,6 +23,7 @@
 using Grasshopper.Kernel.Parameters;
 using Grasshopper.Kernel.Types;
 using System.Runtime.CompilerServices;
+using Rhino.Geometry;
 
 namespace BH.Engine.Grasshopper
 {
@@ -31,6 +32,11 @@ namespace BH.Engine.Grasshopper
         /*******************************************/
         /**** Public Methods                    ****/
         /*******************************************/
+
+        public static T IFromGoo<T>(this IGH_Goo goo, IGH_TypeHint hint = null)
+        {
+            return goo != null ? FromGoo<T>(goo as dynamic, hint) : null;
+        }
 
         public static T FromGoo<T>(this IGH_Goo goo, IGH_TypeHint hint = null)
         {
@@ -63,5 +69,13 @@ namespace BH.Engine.Grasshopper
         }
 
         /*************************************/
+
+        public static T FromGoo<T>(this GH_Surface goo, IGH_TypeHint hint = null) where T : Surface
+        {
+            Brep brep = goo.ScriptVariable() as Brep;
+            if (brep.IsSurface)
+                return (T)(brep.Faces[0] as dynamic);
+            return null;
+        }
     }
 }

--- a/Grasshopper_Engine/Objects/Types/GH_BHoMObject.cs
+++ b/Grasshopper_Engine/Objects/Types/GH_BHoMObject.cs
@@ -100,7 +100,7 @@ namespace BH.Engine.Grasshopper.Objects
         public override bool CastFrom(object source)
         {
             while (source is IGH_Goo)
-                source = ((IGH_Goo)source).ScriptVariable();
+                return CastFrom(Convert.IFromGoo<object>((IGH_Goo)source));
 
             if (source.GetType().Namespace.StartsWith("Rhino.Geometry"))
                 source = BH.Engine.Rhinoceros.Convert.ToBHoM(source as dynamic);

--- a/Grasshopper_Engine/Objects/Types/GH_IBHoMGeometry.cs
+++ b/Grasshopper_Engine/Objects/Types/GH_IBHoMGeometry.cs
@@ -204,7 +204,7 @@ namespace BH.Engine.Grasshopper.Objects
             else if (source is Rhino.Geometry.GeometryBase)
                 m_Value = ((Rhino.Geometry.GeometryBase)source).IToBHoM();
             else if (source is IGH_Goo)
-                return CastFrom(((IGH_Goo)source).ScriptVariable());
+                return CastFrom(Convert.IFromGoo<object>((IGH_Goo)source));
             else if (source is Rhino.Geometry.Vector3d)
                 m_Value = ((Rhino.Geometry.Vector3d)source).ToBHoM();
             else if (source is Rhino.Geometry.Plane)

--- a/Grasshopper_Engine/Objects/Types/GH_IObject.cs
+++ b/Grasshopper_Engine/Objects/Types/GH_IObject.cs
@@ -99,8 +99,8 @@ namespace BH.Engine.Grasshopper.Objects
 
         public override bool CastFrom(object source)
         {
-            while (source is IGH_Goo)
-                source = ((IGH_Goo)source).ScriptVariable();
+            if (source is IGH_Goo)
+                return CastFrom(Convert.IFromGoo<object>((IGH_Goo)source));
 
             if (source.GetType().Namespace.StartsWith("Rhino.Geometry"))
                 source = BH.Engine.Rhinoceros.Convert.ToBHoM(source as dynamic);

--- a/Grasshopper_UI/2.1/Templates/DataAccessor_GH.cs
+++ b/Grasshopper_UI/2.1/Templates/DataAccessor_GH.cs
@@ -74,7 +74,7 @@ namespace BH.UI.Grasshopper.Templates
             if (scriptParam != null)
                 hint = scriptParam.TypeHint;
 
-            return BH.Engine.Grasshopper.Convert.FromGoo<T>(goo, hint);
+            return BH.Engine.Grasshopper.Convert.IFromGoo<T>(goo, hint);
         }
 
         /*************************************/
@@ -91,7 +91,7 @@ namespace BH.UI.Grasshopper.Templates
 
             List<IGH_Goo> goo = new List<IGH_Goo>();
             GH_Accessor.GetDataList<IGH_Goo>(index, goo);
-            return goo.Select(x => BH.Engine.Grasshopper.Convert.FromGoo<T>(x, hint)).ToList();
+            return goo.Select(x => BH.Engine.Grasshopper.Convert.IFromGoo<T>(x, hint)).ToList();
         }
 
         /*************************************/
@@ -107,7 +107,7 @@ namespace BH.UI.Grasshopper.Templates
                 hint = scriptParam.TypeHint;
 
             IGH_Param param = Component.Params.Input[index];
-            return param.VolatileData.StructureProxy.Select(x => x.Cast<IGH_Goo>().Select(y => BH.Engine.Grasshopper.Convert.FromGoo<T>(y, hint)).ToList()).ToList();
+            return param.VolatileData.StructureProxy.Select(x => x.Cast<IGH_Goo>().Select(y => BH.Engine.Grasshopper.Convert.IFromGoo<T>(y, hint)).ToList()).ToList();
 
             // This shows that using the GetDataTree method from GH is actually giving the exact same result with the exact same problem of collecting the entire data instead of a subtree
             /*IGH_Structure goo = Activator.CreateInstance(typeof(GH_Structure<>).GetGenericTypeDefinition().MakeGenericType(new Type[] { param.Type })) as IGH_Structure;
@@ -152,7 +152,7 @@ namespace BH.UI.Grasshopper.Templates
         private List<List<T>> ConvertDataTree<T, TG>(GH_Structure<TG> structure, int index, List<List<T>> result) where TG : IGH_Goo
         {
             GH_Accessor.GetDataTree(index, out structure);
-            result = structure.Branches.Select(x => x.Select(y => BH.Engine.Grasshopper.Convert.FromGoo<T>(y)).ToList()).ToList();
+            result = structure.Branches.Select(x => x.Select(y => BH.Engine.Grasshopper.Convert.IFromGoo<T>(y)).ToList()).ToList();
             return result;
         }
 


### PR DESCRIPTION


<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Closes #386 
<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/Eohx13r1C-NNjMreEkKlO1IBkltDreEhrGFVVx5G_RsGww?e=vLmFMi

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixes the overload `FromGoo(GH_Surface)` since Grasshopper `GH_Surface` specifies `<Brep>` rather than `<Surface>`. See https://github.com/BHoM/Grasshopper_Toolkit/issues/386 for more.

### Additional comments
<!-- As required -->