### PR TITLE
Grasshopper_Toolkit - Issue 226 - Being able to input arrays

### DIFF
--- a/Grasshopper_UI/2.1/Templates/DataAccessor_GH.cs
+++ b/Grasshopper_UI/2.1/Templates/DataAccessor_GH.cs
@@ -81,17 +81,14 @@ namespace BH.UI.Grasshopper.Templates
 
         public override List<T> GetDataList<T>(int index)
         {
-            if (GH_Accessor == null)
-                return new List<T>();
+            return GetDataCollection<T>(index).ToList();
+        }
 
-            IGH_TypeHint hint = null;
-            Param_ScriptVariable scriptParam = Component.Params.Input[index] as Param_ScriptVariable;
-            if (scriptParam != null)
-                hint = scriptParam.TypeHint;
+        /*************************************/
 
-            List<IGH_Goo> goo = new List<IGH_Goo>();
-            GH_Accessor.GetDataList<IGH_Goo>(index, goo);
-            return goo.Select(x => BH.Engine.Grasshopper.Convert.IFromGoo<T>(x, hint)).ToList();
+        public override T[] GetDataArray<T>(int index)
+        {
+            return GetDataCollection<T>(index).ToArray();
         }
 
         /*************************************/
@@ -154,6 +151,23 @@ namespace BH.UI.Grasshopper.Templates
             GH_Accessor.GetDataTree(index, out structure);
             result = structure.Branches.Select(x => x.Select(y => BH.Engine.Grasshopper.Convert.IFromGoo<T>(y)).ToList()).ToList();
             return result;
+        }
+
+        /*************************************/
+
+        private IEnumerable<T> GetDataCollection<T>(int index)
+        {
+            if (GH_Accessor == null)
+                return new T[0];
+
+            IGH_TypeHint hint = null;
+            Param_ScriptVariable scriptParam = Component.Params.Input[index] as Param_ScriptVariable;
+            if (scriptParam != null)
+                hint = scriptParam.TypeHint;
+
+            List<IGH_Goo> goo = new List<IGH_Goo>();
+            GH_Accessor.GetDataList<IGH_Goo>(index, goo);
+            return goo.Select(x => BH.Engine.Grasshopper.Convert.FromGoo<T>(x, hint));
         }
 
         /*************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on https://github.com/BHoM/BHoM_UI/pull/117
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #226

### Test files
<!-- Link to test files to validate the proposed changes -->
Note that, even you need to use https://github.com/BHoM/BHoM_Engine/pull/1124 to be able to input arrays, although it does not represent a code-wise dependency.
https://burohappold.sharepoint.com/:f:/s/BHoM/EjmxIfvj4WNBvi9qWzVvunoBwjYJX03lohJTTu8WHAxAhA?e=JpiJCu

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Adds `DataAccessor_GH.GetDataArray(int index)`

### Additional comments
<!-- As required -->
This pr is to support arrays (e.g. `int[]`) as inputs from the visual programming interface. it does so by adding another getter `GetDataArray(int)`.

There are a series of cases that this does not solve voluntarily, where the arrays are nested, e.g. `List<int[]>`