### PR TITLE
Translate `long` type into a suitable Grasshopper parameter 

### DIFF
--- a/Grasshopper_UI/2.1/Templates/CallerComponent.cs
+++ b/Grasshopper_UI/2.1/Templates/CallerComponent.cs
@@ -327,8 +327,10 @@ namespace BH.UI.Grasshopper.Templates
                     break;
                 case "System.Int16":
                 case "System.Int32":
-                case "System.Int64":
                     param = new Param_Integer();
+                    break;
+                case "System.Int64":
+                    param = new Param_Time();
                     break;
                 case "System.String":
                     param = new Param_String();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #394 
<!-- Add short description of what has been fixed -->
Info about the problem at the related issue page. 
Grasshopper was translating a `long` into an `Param_Integer` parameter, and thus failing.
It now translates into a `Param_Time` parameter, which stores the data as a `long` - it was designed to store the time as ticks (milliseconds).

### Test files
<!-- Link to test files to validate the proposed changes -->
Test file at #394. The test script relies on the following branches:
- https://github.com/BHoM/BHoM/pull/541
- https://github.com/BHoM/BHoM_Engine/pull/1150


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- A `System.Int64` or `long` is now correctly parsed into a `Param_Time` parameter

### Additional comments
<!-- As required -->