### PR TITLE
Solves #396

### DIFF
--- a/Grasshopper_Engine/Query/Type.cs
+++ b/Grasshopper_Engine/Query/Type.cs
@@ -38,17 +38,18 @@ namespace BH.Engine.Grasshopper
 
         public static Type Type(this IGH_Param param, Caller caller = null)
         {
+            Type type;
             if (param == null)
-                return typeof(object);
+                type = typeof(object);
 
             if (param is Param_ScriptVariable)
-                return Type(((Param_ScriptVariable)param).TypeHint, param.Access);
-
+                type = Type(((Param_ScriptVariable)param).TypeHint, param.Access);
             else if (caller != null)
-                return (caller.InputParams.Find(x => x.Name == param.NickName))?.DataType;
-
+                type = caller.InputParams.Find(x => x.Name == param.NickName)?.DataType;
             else
-                return param.Type;
+                type = param.Type;
+
+            return type == null ? typeof(object) : type;
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #396 
<!-- Add short description of what has been fixed -->
Rhino crashes altogether if you open a script with a  `CustomObjecy` component that serialised a `Type` that doesn't exist anymore in the BHoM.

### Test files
<!-- Link to test files to validate the proposed changes -->
@IsakNaslundBh would you mind using the file that triggered the issue in the first place?

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Make sure that `Engine.Grasshopper.Query.Type(this IGH_Param param, Caller caller = null)` never returns `null`.

### Additional comments
<!-- As required -->
This is quite critical, since it is crashing the whole Rhino.