### PR TITLE
PostBuild events are now copying only files relevant to Grasshopper

### DIFF
--- a/Grasshopper_Engine/Grasshopper_Engine.csproj
+++ b/Grasshopper_Engine/Grasshopper_Engine.csproj
@@ -150,6 +150,10 @@
     <Error Condition="!Exists('..\packages\Grasshopper.0.9.76\build\net35\Grasshopper.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grasshopper.0.9.76\build\net35\Grasshopper.targets'))" />
   </Target>
   <Import Project="..\packages\Grasshopper.0.9.76\build\net35\Grasshopper.targets" Condition="Exists('..\packages\Grasshopper.0.9.76\build\net35\Grasshopper.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>rem copy Grasshopper_Engine to BHoM/Assemblies folder
+Copy /Y "$(TargetDir)$(TargetName).dll" "$(AppData)\BHoM\Assemblies\$(TargetName).dll"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Grasshopper_UI/Grasshopper_UI.csproj
+++ b/Grasshopper_UI/Grasshopper_UI.csproj
@@ -316,15 +316,10 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>call "..\..\BHoM_UI\Build\UI_PostBuild.exe" ..\..\ "$(AppData)\BHoM\Assemblies"
-
+    <PostBuildEvent>rem copy .gh file to BHoM/Assembly folder
 Copy /Y "$(TargetDir)$(TargetName).dll" "$(AppData)\BHoM\Assemblies\$(TargetName).gha"
 
-
-IF EXIST $(AppData)\Grasshopper\Libraries\BHoM (
-RD /S /Q $(AppData)\Grasshopper\Libraries\BHoM
-)
-
+rem create .ghlink file
 echo $(AppData)\BHoM\Assemblies\$(TargetName).gha &gt; "$(AppData)\Grasshopper\Libraries\$(TargetName).ghlink"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #407 
<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
There is no test file, as this is a compile time intervention. To test, you can:
1. Remove your Grasshopper_Toolkit/Build folder
2. Remove your AppData/Roaming/BHoM/Assemblies folder
3. Compile the BHoM_UI
4. Verify that neither of "BH.UI.Grasshopper.gha" nor "Grasshopper_Engine" is in the  AppData/Roaming/BHoM/Assemblies folder
5. Compile the Grasshopper_Toolkit solution
6. Verify that both of "BH.UI.Grasshopper.gha" and "Grasshopper_Engine" are in the  AppData/Roaming/BHoM/Assemblies folder
7. Verify that "AppData/Roaming/Grasshopper/Libraries/BH.UI.Grasshopper.ghlink" exists

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Add post-build events to the Grasshopper_Engine to copy files over to AppData/BHoM/Assemblies
- Amend post-build events to the Grasshopper_UI to copy over only "BH.UI.Grasshopper.gha" and create "AppData/Roaming/Grasshopper/Libraries/BH.UI.Grasshopper.ghlink"
