### PR TITLE
Update AssemblyVersion and AssemblyFileVersion to 3.0.0.0

### DIFF
--- a/Grasshopper_Engine/Properties/AssemblyInfo.cs
+++ b/Grasshopper_Engine/Properties/AssemblyInfo.cs
@@ -54,5 +54,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.0.0")]

--- a/Grasshopper_UI/Grasshopper_UI.csproj
+++ b/Grasshopper_UI/Grasshopper_UI.csproj
@@ -156,7 +156,7 @@
     <Compile Include="Components\Adapter\Push.cs" />
     <Compile Include="Others\Logging.cs" />
     <Compile Include="Templates\BHoMParam.cs" />
-    <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Components\Engine\Explode.cs" />
     <Compile Include="Components\Engine\GetInfo.cs" />
     <Compile Include="Components\Engine\Query.cs" />

--- a/Grasshopper_UI/Properties/AssemblyInfo.cs
+++ b/Grasshopper_UI/Properties/AssemblyInfo.cs
@@ -56,5 +56,5 @@ using Grasshopper.Kernel;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.4.0.0")]
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.0.0")]


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
 
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #424
<!-- Add short description of what has been fixed -->

### Test
<!-- Link to test files to validate the proposed changes -->
Make sure that:
- All the .csproj files in the solution have the properties  `AssemblyFileVersion` to `3.0.0.0` and `AssemblyVersion` to `3.0.0.0`.
- The AssemblyCopyright reads `[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]`

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Update `AssemblyFileVersion` to `3.0.0.0`
- Update `AssemblyVersion` to `3.0.0.0`
- Moved the `AssemblyInfo.cs` file of the Grasshopper_UI project into the `Properties` folder