### PR TITLE
Preview for trimmed surfaces

### DIFF
--- a/Grasshopper_Engine/Compute/RenderMeshes.cs
+++ b/Grasshopper_Engine/Compute/RenderMeshes.cs
@@ -160,7 +160,11 @@ namespace BH.Engine.Grasshopper
 
         public static void RenderMeshes(BHG.NurbsSurface surface, Rhino.Display.DisplayPipeline pipeline, DisplayMaterial material)
         {
-            pipeline.DrawBrepShaded(RHG.Brep.CreateFromSurface(surface.ToRhino()), material);
+            RHG.GeometryBase geometry = surface.ToRhino();
+            if (geometry is RHG.Surface)
+                geometry = RHG.Brep.CreateFromSurface((RHG.Surface)geometry);
+
+            pipeline.DrawBrepShaded((RHG.Brep)geometry, material);
         }
 
         /***************************************************/

--- a/Grasshopper_Engine/Compute/RenderWires.cs
+++ b/Grasshopper_Engine/Compute/RenderWires.cs
@@ -156,8 +156,11 @@ namespace BH.Engine.Grasshopper
 
         public static void RenderWires(BHG.NurbsSurface surface, Rhino.Display.DisplayPipeline pipeline, Color bhColour)
         {
-            RHG.Surface rSurface = surface.ToRhino();
-            pipeline.DrawSurface(rSurface, bhColour, 2);
+            RHG.GeometryBase geometry = surface.ToRhino();
+            if (geometry is RHG.Surface)
+                geometry = RHG.Brep.CreateFromSurface((RHG.Surface)geometry);
+
+            pipeline.DrawBrepWires((RHG.Brep)geometry, bhColour, 2);
         }
 
         /***************************************************/

--- a/Grasshopper_Engine/Convert/FromGoo.cs
+++ b/Grasshopper_Engine/Convert/FromGoo.cs
@@ -75,7 +75,8 @@ namespace BH.Engine.Grasshopper
             Brep brep = goo.ScriptVariable() as Brep;
             if (brep.IsSurface)
                 return (T)(brep.Faces[0].UnderlyingSurface() as dynamic);
-            return default(T);
+            else
+                return (T)(brep as dynamic);
         }
     }
 }


### PR DESCRIPTION
### NOTE: Depends on 
[#603](https://github.com/BHoM/BHoM/pull/603)
[#1319](https://github.com/BHoM/BHoM_Engine/pull/1319)
[#122](https://github.com/BHoM/Rhinoceros_Toolkit/pull/122)

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #430

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Test files are located on [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%2FGeometry%5FoM%2DIssue425%2DCreationOfTrimmedNurbsSurfaceDefinition). To run it, please switch to the branches related to the following PRs:
- [#603 ](https://github.com/BHoM/BHoM/pull/603)
- [#1319](https://github.com/BHoM/BHoM_Engine/pull/1319)
- [#122](https://github.com/BHoM/Rhinoceros_Toolkit/pull/122)
- [#435](https://github.com/BHoM/Grasshopper_Toolkit/pull/435)
- [#435](https://github.com/BHoM/Revit_Toolkit/pull/435)
- [#183](https://github.com/BHoM/Dynamo_Toolkit/pull/183)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Preview for trimmed surfaces has been added.

### Additional comments
Updated copy of #431.
Please see [#603](https://github.com/BHoM/BHoM/pull/603).