### PR TITLE
The explode component expires continuously if an input with an empty structure is plugged in

### DIFF
--- a/Grasshopper_UI/Components/Engine/Explode.cs
+++ b/Grasshopper_UI/Components/Engine/Explode.cs
@@ -124,7 +124,7 @@ namespace BH.UI.Grasshopper.Components
 
         private bool IsExpired()
         {
-            if (Params.Input.Count == 1 && Params.Input[0].SourceCount == 0) // Nothing plugged in
+            if (Params.Input.Count == 1 && (Params.Input[0].SourceCount == 0 || Params.Input[0].VolatileDataCount == 0)) // Nothing plugged in or empty structure
             {
                 return false;
             }

--- a/Grasshopper_UI/Components/oM/CreateType.cs
+++ b/Grasshopper_UI/Components/oM/CreateType.cs
@@ -27,6 +27,7 @@ using BH.UI.Grasshopper.Templates;
 using BH.UI.Templates;
 using BH.UI.Components;
 using BH.Engine.Reflection;
+using GH_IO.Serialization;
 
 namespace BH.UI.Grasshopper.Components
 {
@@ -50,6 +51,19 @@ namespace BH.UI.Grasshopper.Components
             Type type = Caller.SelectedItem as Type;
             if (type != null)
                 Message = type.ToText();
+        }
+
+        /*******************************************/
+
+        public override bool Read(GH_IReader reader)
+        {
+            bool success = base.Read(reader);
+
+            Type type = Caller.SelectedItem as Type;
+            if (type != null)
+                Message = type.ToText();
+
+            return success;
         }
 
         /*******************************************/

--- a/Grasshopper_UI/Global/GlobalSearch.cs
+++ b/Grasshopper_UI/Global/GlobalSearch.cs
@@ -78,7 +78,7 @@ namespace BH.UI.Grasshopper.Global
                 if (request != null && request.Location != null)
                 {
                     System.Drawing.Point location = new System.Drawing.Point((int)request.Location.X, (int)request.Location.Y);
-                    canvas.InstantiateNewObject(node.Id, initCode, canvas.PointToClient(location), true);
+                    canvas.InstantiateNewObject(node.Id, initCode, canvas.Viewport.UnprojectPoint(canvas.PointToClient(location)), true);
                 }
                 else
                 {

--- a/Grasshopper_UI/Global/GlobalSearch.cs
+++ b/Grasshopper_UI/Global/GlobalSearch.cs
@@ -75,7 +75,8 @@ namespace BH.UI.Grasshopper.Global
                     initCode = request.SelectedItem.ToJson();
 
                 GH_Canvas canvas = GH.Instances.ActiveCanvas;
-                canvas.InstantiateNewObject(node.Id, initCode, canvas.CursorCanvasPosition, true);
+                System.Drawing.Point location = new System.Drawing.Point((int)request.Location.X, (int)request.Location.Y);
+                canvas.InstantiateNewObject(node.Id, initCode, canvas.PointToClient(location), true);
             }
 
         }

--- a/Grasshopper_UI/Global/GlobalSearch.cs
+++ b/Grasshopper_UI/Global/GlobalSearch.cs
@@ -75,10 +75,16 @@ namespace BH.UI.Grasshopper.Global
                     initCode = request.SelectedItem.ToJson();
 
                 GH_Canvas canvas = GH.Instances.ActiveCanvas;
-                System.Drawing.Point location = new System.Drawing.Point((int)request.Location.X, (int)request.Location.Y);
-                canvas.InstantiateNewObject(node.Id, initCode, canvas.PointToClient(location), true);
+                if (request != null && request.Location != null)
+                {
+                    System.Drawing.Point location = new System.Drawing.Point((int)request.Location.X, (int)request.Location.Y);
+                    canvas.InstantiateNewObject(node.Id, initCode, canvas.PointToClient(location), true);
+                }
+                else
+                {
+                    canvas.InstantiateNewObject(node.Id, initCode, canvas.CursorCanvasPosition, true);
+                }
             }
-
         }
 
         /*******************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #417
Closes #419 
Closes #311 (Bonus!!!! 🏆 )
<!-- Add short description of what has been fixed -->


### Test files 
<!-- Link to test files to validate the proposed changes -->
For #417: (review by @jdarcyBHE  && (@alelom || @IsakNaslundBh)) :heavy_check_mark:
1. Create a `Data` parameter
1. Create and `Explode` component
1. Plug `Data` into `Explode` now do any other thing
1. Try to CTRL + Z 
1. Check that it can undo what you have done at point 3.

For #419 (review by @JosefTaylor )
1.  Create a `CreateType` component
1. Select a `Type`
1. Copy and paste the component
1. Check that it still shows the banner with the type

For #311: (review by @FraserGreenroyd )
Follow the procedure illustrated by @IsakNaslundBh in [this gif](https://github.com/BHoM/Grasshopper_Toolkit/issues/311#issue-396476688)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Make sure that `Explode` does not refresh continuously if an empty structure is plugged in
- `CreateType` maintains the banner now after serialisation/deserialisation routines
- Component is now created where the menu first appears, rather than where the mouse cursor is

### Additional comments
<!-- As required -->
@IsakNaslundBh @alelom putting you in as reviewer because this can potentially be quite dangerous. Would you mind just opening some scripts that you use and check that the `Explode` works properly?

@JosefTaylor Can you check #419 is fixed?

I added comments on who should review what to make it easier to coordinate.
If the review is successfull, you can give a green tick and add the `do-not-merge` label.
I'll take care of coordinating all the green/red ticks.