### PR TITLE
Checking for Dictionary type in the conversion from framework types to Grasshopper goos

### DIFF
--- a/Grasshopper_UI/Templates/CallerComponent.cs
+++ b/Grasshopper_UI/Templates/CallerComponent.cs
@@ -38,6 +38,7 @@ using System.Linq;
 using BH.Engine.Grasshopper;
 using BH.UI.Grasshopper.Components;
 using BH.UI.Grasshopper.Others;
+using System.Collections;
 
 namespace BH.UI.Grasshopper.Templates
 {
@@ -387,12 +388,13 @@ namespace BH.UI.Grasshopper.Templates
                             param = new Param_IObject();
                         else if (typeof(Enum).IsAssignableFrom(type))
                             param = new Param_Enum();
+                        else if (typeof(IDictionary).IsAssignableFrom(type))
+                            param = new Param_Dictionary();
                         else
                         {
                             param = new Param_ScriptVariable();
                             param.AttributesChanged += Param_AttributesChanged;
                         }
-
                     }
                     break;
             }


### PR DESCRIPTION
I am not sure why this check was not here.

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #457 
<!-- Add short description of what has been fixed -->
 

### Test procedure
<!-- Link to test files to validate the proposed changes -->
1. Use the installer created after the adapter merge refactoring
1. Pull this branch
1. Compile this solution
1. Open Grasshopper and instantiate a `Create.GetRequest` component through the object initialiser

To see if the fix has effect you need to check the following:
A. Hover on the `Header` component and make sure that it is not a `ScriptVariable`, but rather a `Dictionary` parameter (a Grasshopper parameter, not a `System.Dictionary`)
B. Copy and paste the component - make sure that no grasshopper expection windows is raised.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
