### PR TITLE
Add versioning for ValueList component

### DIFF
--- a/Grasshopper_UI/Templates/CallerValueList.cs
+++ b/Grasshopper_UI/Templates/CallerValueList.cs
@@ -144,8 +144,27 @@ namespace BH.UI.Grasshopper.Templates
             {
                 int selection = -1;
                 reader.TryGetInt32("Selection", ref selection);
+
                 if (selection >= 0 && selection < ListItems.Count)
-                    this.SelectItem(selection);
+                {
+                    //To acount for changes in orders of enums and dataset, match name of previous item with name of new items instead of 
+                    //simply relying on previous index.
+
+                    //Get name of selected item
+                    string prevName = ListItems[selection].Name;
+                    //Find index in list of new items with matching name to selected name
+                    int index = Caller.GetChoiceNames().IndexOf(prevName);
+                    //Make sure component is up to date with backend caller
+                    UpdateFromSelectedItem();
+
+                    //If index is found, update to this. If item is not found, use previous selection.
+                    if (index != -1)
+                        selection = index;
+
+                    //As item count might have been reduced in UpdateFromSelected, a final check that the selection is not out of bounds needed.
+                    if (selection < ListItems.Count)
+                        this.SelectItem(selection);
+                }
                 return true;
             }
             else
@@ -162,7 +181,6 @@ namespace BH.UI.Grasshopper.Templates
             }
             return base.HtmlHelp_Source();
         }
-
 
         /*************************************/
         /**** Initialisation via String   ****/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #485

<!-- Add short description of what has been fixed -->
Checking values by name and not just relying on indexing during de-serialisation.

Done in support of handling changes requested here: https://github.com/BHoM/BHoM_Adapter/pull/205#discussion_r391729163

Without this PR, changing the order of enums lead quite dangerous errors:

![image](https://user-images.githubusercontent.com/22005920/76626225-164e6880-6539-11ea-90a7-136048f08459.png)

WIth PR:

![image](https://user-images.githubusercontent.com/22005920/76626496-86f58500-6539-11ea-93fb-4f648edf5650.png)


This PR makes sure the value list is up to date, and tries to pick the value based on name rather than just index.



### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/Etgls_Qrj7NKiaxSAEqAvvoBFOElFZYcwja8hIAVEkniVA?e=RxBFsw

Requires https://github.com/BHoM/BHoM_Adapter/pull/205 to test that the behaviour is handled correctly.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->

@adecler as the selection index is stored on the GH side of things, I could not find a way to put this change in the BHoM_UI/Versioning toolkit. If I am in the wrong here, please let me know.