### PR TITLE
Fix message notes covering all other messages

### DIFF
--- a/Grasshopper_UI/Others/Logging.cs
+++ b/Grasshopper_UI/Others/Logging.cs
@@ -40,15 +40,22 @@ namespace BH.UI.Grasshopper.Others
         {
             if (events.Count > 0)
             {
-                foreach (Event e in events)
-                {
-                    if (e.Type == EventType.Error)
-                        component.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.Message);
-                    else if (e.Type == EventType.Warning)
-                        component.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, e.Message);
-                    else if (e.Type == EventType.Note)
-                        component.AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, e.Message);
-                }
+                var errors = events.Where(x => x.Type == EventType.Error);
+                var warnings = events.Where(x => x.Type == EventType.Warning);
+                var notes = events.Where(x => x.Type == EventType.Note);
+
+                foreach (Event e in errors)
+                    component.AddRuntimeMessage(GH_RuntimeMessageLevel.Error, e.Message);
+
+                foreach (Event e in warnings)
+                    component.AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, e.Message);
+
+                GH_RuntimeMessageLevel noteLevel = GH_RuntimeMessageLevel.Remark;
+                if (errors.Count() > 0 || warnings.Count() > 0)
+                    noteLevel = GH_RuntimeMessageLevel.Blank;
+
+                foreach (Event e in notes)
+                    component.AddRuntimeMessage(noteLevel, e.Message);
             }
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #480 

<!-- Add short description of what has been fixed -->

Think this resolves the issue, in a less than elegant way.

So problem seem to stem from the `RuntimeMessageLevel` method on the base `GH_Component` and or `GH_ActiveObject`. This has the current behaviour:

1. `Error` added before any `Remark` -> `Error`
1. `Error` added after `Remark` -> `Remark`
1. `Error` added before `Warning` -> `Error`
1. `Error` added after `Warning` -> `Error`
1. `Warning` added before `Remark` -> `Remark`
1. `Warning` added after `Remark` -> `Remark`

Basically, error trumps everything, if it is higher up in the list, if not, Remark trumps the rest. Problem seem to be the enum itself having a quite weird value indexing, which then fail when comparing:

```
    //
    // Summary:
    //     Indicates the severity of a runtime message.
    public enum GH_RuntimeMessageLevel : byte
    {
        //
        // Summary:
        //     No warnings or errors were recorded during solver-time processes
        Blank = 0,
        //
        // Summary:
        //     One or more warnings (but no errors) were recorded during solver-time processes
        Warning = 10,
        //
        // Summary:
        //     One or more errors (and possibly any number of warnings) were recorded during
        //     solver-time processes.
        Error = 20,
        //
        // Summary:
        //     One of more messages (but no warnings and no errors) were recorded during solver-time
        //     processes.
        Remark = 255
    }
```
(Also note that the description is wrong, as we have experienced).

Now, on the GH_ActiveObject, the `RuntimeMessageLevel` is virtual, so hoped to be able to override it, but nono, that can not be done, cause the GH_Component has it marked as `sealed`.

So some solutions I could think of was

1. The one implemented, force add notes as blanks instead of remarks, if any warnings/errors are found. If noting is found, add as remark, to make sure they show up on the menu.
2. override the GH_ActiveObejct ourselfs, instead of the GH_Component, but that mean adding in a LOT of boilerplate code currently handled by the GH_Component.
3. Override the GH_CompoentAttribute class to handle the message level from there. This would be quite deep in everything though, as we would need to override the general rendering methods etc.

Hence, even though I am not a massive fan of the proposed solution, I think it might be the best one I can think of for now...

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->