### PR TITLE
Fix duplicate components after unload & reload of GH

### DIFF
--- a/Grasshopper_UI/Global/GlobalSearch.cs
+++ b/Grasshopper_UI/Global/GlobalSearch.cs
@@ -53,6 +53,9 @@ namespace BH.UI.Grasshopper.Global
         public static void Activate()
         {
             GH.Instances.CanvasCreated += Instances_CanvasCreated;
+
+            GlobalSearch.RemoveHandler(typeof(GlobalSearchMenu).FullName);
+            GlobalSearch.ItemSelected += GlobalSearch_ItemSelected;
         }
 
 
@@ -63,8 +66,7 @@ namespace BH.UI.Grasshopper.Global
         private static void Instances_CanvasCreated(GH_Canvas canvas)
         {
             GlobalSearch.Activate(canvas.FindForm());
-            GlobalSearch.ItemSelected += GlobalSearch_ItemSelected;
-
+            
             if (GH.Instances.DocumentEditor != null)
                 GH.Instances.DocumentEditor.Activated += (sender, e) => AddLocalComponentProxies();
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 

https://github.com/BHoM/BHoM_UI/pull/264
   
### Issues addressed by this PR

Closes #504

Grasshopper effectively loads the BHoM plugin multiple times so a simple check on a static boolean doesn't work. Finding teh proper way to remove the event handler when GH was unloaded proved to be tricky so I decided to just ask the event handler to remove pre-existing handles of a specific type (has to be done via string since types are actually not equal between loaded instances)

Everything still works fine if you have multiple instances of GH, even if you unload/reload some of them.

### Additional comments
I really really wanted to get my list of bugs down to zero 😋 