### PR TITLE
Remove dependency to UI_PostBuild

### DIFF
--- a/Grasshopper_UI/Grasshopper_UI.csproj
+++ b/Grasshopper_UI/Grasshopper_UI.csproj
@@ -143,10 +143,6 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\UI_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UI_PostBuild">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\UI_PostBuild.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Components\Engine\External.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #524

Simply removes the reference to UI_PostBuild. No additional action needed given that UI_PostBuild isn't actually used anywhere in this repo.

### Test files
Just make sure this still compiles
