### PR TITLE
Usage log now saving caller type name instead of caller name

### DIFF
--- a/Grasshopper_UI/CallerComponent/GH_Component.cs
+++ b/Grasshopper_UI/CallerComponent/GH_Component.cs
@@ -112,7 +112,7 @@ namespace BH.UI.Grasshopper.Templates
             Helpers.ShowEvents(this, events);
 
             if (DA.Iteration == 0)
-                Engine.UI.Compute.LogUsage("Grasshopper", GH.Versioning.VersionString, InstanceGuid, Caller.Name, Caller.SelectedItem, events);
+                Engine.UI.Compute.LogUsage("Grasshopper", GH.Versioning.VersionString, InstanceGuid, Caller.GetType().Name, Caller.SelectedItem, events);
         }
 
         /*******************************************/

--- a/Grasshopper_UI/Templates/CallerValueList.cs
+++ b/Grasshopper_UI/Templates/CallerValueList.cs
@@ -111,7 +111,7 @@ namespace BH.UI.Grasshopper.Templates
                 this.m_data.Append(result.IToGoo(), new GH_Path(0));
             }
 
-            Engine.UI.Compute.LogUsage("Grasshopper", GH.Versioning.VersionString, InstanceGuid, Caller.Name, Caller.SelectedItem);
+            Engine.UI.Compute.LogUsage("Grasshopper", GH.Versioning.VersionString, InstanceGuid, Caller.GetType().Name, Caller.SelectedItem);
         }
 
         /*******************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #534

Same as for other UIs: Caller Type name should be saved instead of caller name in usage log.
