### PR TITLE
Fix error messages spreading to BHoMParam components

### DIFF
--- a/Grasshopper_UI/Helpers/Logging.cs
+++ b/Grasshopper_UI/Helpers/Logging.cs
@@ -37,7 +37,7 @@ namespace BH.UI.Grasshopper
         /**** Public Methods              ****/
         /*************************************/
 
-        public static void ShowEvents(GH_ActiveObject component, List<Event> events)
+        public static void ShowEvents(GH_ActiveObject component, List<Event> events, bool clearShownEvents = true)
         {
             if (events.Count > 0)
             {
@@ -65,6 +65,9 @@ namespace BH.UI.Grasshopper
                     foreach (Event e in notes)
                         component.AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, e.Message);
                 }
+
+                if (clearShownEvents)
+                    Engine.Reflection.Compute.ClearCurrentEvents();
             }
         }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #545 

The BHoMParam components don't have a clear entry point to clear pre-existing event messages. This leads to situations like shown in issue #545. 

The simplest solution seems to clear the events once they have been pushed to Grasshopper. I have left that as an optional argument to the `ShowEvents` method just in case there would be exceptional cases. 

### Test files
Test file provided in the issue.

