### PR TITLE
Fix added param input/output when already exists

### DIFF
--- a/Grasshopper_UI/CallerComponent/OncallerModified.cs
+++ b/Grasshopper_UI/CallerComponent/OncallerModified.cs
@@ -88,7 +88,18 @@ namespace BH.UI.Grasshopper.Templates
 
         protected virtual void UpdateInput(ParamAdded update)
         {
-            Params.RegisterInputParam(update.Param.ToGH_Param(), update.Index);
+            IGH_Param newParam = update.Param.ToGH_Param();
+
+            // If there is already a param with the same name, delete it but keep the wire connections
+            // Same approach as `UpdateInput(ParamUpdated update)` but with index provided by ParamAdded
+            IGH_Param match = Params.Input.Find(x => x.Name == update.Name);
+            if (match != null)
+            {
+                MoveLinks(match, newParam);
+                Params.UnregisterInputParameter(match);
+            }
+
+            Params.RegisterInputParam(newParam, update.Index);
         }
 
         /*******************************************/
@@ -143,7 +154,18 @@ namespace BH.UI.Grasshopper.Templates
 
         protected virtual void UpdateOutput(ParamAdded update)
         {
-            Params.RegisterOutputParam(update.Param.ToGH_Param(), update.Index);
+            IGH_Param newParam = update.Param.ToGH_Param();
+
+            // If there is already a param with the same name, delete it but keep the wire connections
+            // Same approach as `UpdateOutput(ParamUpdated update)` but with index provided by ParamAdded
+            IGH_Param match = Params.Output.Find(x => x.Name == update.Name);
+            if (match != null)
+            {
+                newParam.NewInstanceGuid(match.InstanceGuid);
+                Params.UnregisterOutputParameter(match);
+            }
+
+            Params.RegisterOutputParam(newParam, update.Index);
         }
 
         /*******************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #537 

In the rare instance when a component was saved incorrectly (from previous version of the code), we might run the risk of having duplicated inputs/outputs. The situation occurs when a param is on the Grasshopper component but not saved by BHoM. So when we reopen the file, the BHoM_UI will ask for that input/output to be added again.

This PR fixes that issues by making sure we delete the old GH param after having moved the wires across to the new one. So it's very similar to an update with the difference that the position of the param is dictated by the the info in `ParamAdded` instead of the location of the old GH param. 

@LMarkowski, added you as review since you had raised the original issue in https://github.com/BHoM/BHoM_UI/pull/304#pullrequestreview-489394179

@BingWangUS , added you since you raised similar concerns in Teams

@IsakNaslundBh , added you just so you can review the code itself. It's a fairly straightforward change but better safe than sorry 😄 

