### PR TITLE
Add ability to bake BHoMObjects and BHoMGeometry

### DIFF
--- a/Grasshopper_Engine/Objects/Types/GH_BHoMObject.cs
+++ b/Grasshopper_Engine/Objects/Types/GH_BHoMObject.cs
@@ -36,7 +36,7 @@ using BH.Engine.Serialiser;
 
 namespace BH.Engine.Grasshopper.Objects
 {
-    public class GH_BHoMObject : GH_BHoMGoo<object>, IGH_PreviewData, GH_ISerializable
+    public class GH_BHoMObject : GH_BHoMGoo<object>, IGH_PreviewData, IGH_BakeAwareData, GH_ISerializable
     {
         /*******************************************/
         /**** Properties                        ****/
@@ -208,6 +208,29 @@ namespace BH.Engine.Grasshopper.Objects
             }
         }
 
+        /***************************************************/
+        /**** IGH_BakeAwareData methods                 ****/
+        /***************************************************/
+
+        public bool BakeGeometry(RhinoDoc doc, ObjectAttributes att, out Guid obj_guid)
+        {
+            if (m_RhinoGeometry != null)
+            {
+                if (att == null)
+                    att = new ObjectAttributes();
+
+                BHoMObject bhObj = Value as BHoMObject;
+
+                if (string.IsNullOrEmpty(att.Name) && bhObj != null && !string.IsNullOrWhiteSpace(bhObj.Name))
+                    att.Name = bhObj.Name;
+
+                obj_guid = doc.Objects.Add(GH_Convert.ToGeometryBase(m_RhinoGeometry), att);
+                return true;
+            }
+
+            obj_guid = Guid.Empty;
+            return false;
+        }
 
         /***************************************************/
         /**** Private Fields                            ****/

--- a/Grasshopper_Engine/Objects/Types/GH_IObject.cs
+++ b/Grasshopper_Engine/Objects/Types/GH_IObject.cs
@@ -36,7 +36,7 @@ using BH.Engine.Serialiser;
 
 namespace BH.Engine.Grasshopper.Objects
 {
-    public class GH_IObject : GH_BHoMGoo<object>, IGH_PreviewData, GH_ISerializable
+    public class GH_IObject : GH_BHoMGoo<object>, IGH_PreviewData, IGH_BakeAwareData, GH_ISerializable
     {
         /*******************************************/
         /**** Properties                        ****/
@@ -210,6 +210,29 @@ namespace BH.Engine.Grasshopper.Objects
             }
         }
 
+        /***************************************************/
+        /**** IGH_BakeAwareData methods                 ****/
+        /***************************************************/
+
+        public bool BakeGeometry(RhinoDoc doc, ObjectAttributes att, out Guid obj_guid)
+        {
+            if (m_RhinoGeometry != null)
+            {
+                if (att == null)
+                    att = new ObjectAttributes();
+
+                BHoMObject bhObj = Value as BHoMObject;
+
+                if (string.IsNullOrEmpty(att.Name) && bhObj != null && !string.IsNullOrWhiteSpace(bhObj.Name))
+                    att.Name = bhObj.Name;
+
+                obj_guid = doc.Objects.Add(GH_Convert.ToGeometryBase(m_RhinoGeometry), att);
+                return true;
+            }
+
+            obj_guid = Guid.Empty;
+            return false;
+        }
 
         /***************************************************/
         /**** Private Fields                            ****/

--- a/Grasshopper_UI/Components/Parameters/Param_BHoMGeometry.cs
+++ b/Grasshopper_UI/Components/Parameters/Param_BHoMGeometry.cs
@@ -22,11 +22,15 @@
 
 using BH.UI.Grasshopper.Properties;
 using BH.UI.Grasshopper.Templates;
+using Grasshopper.Kernel;
 using System;
+using Rhino;
+using Rhino.DocObjects;
+using System.Collections.Generic;
 
 namespace BH.UI.Grasshopper.Parameters
 {
-    public class Param_BHoMGeometry : BHoMParam<Engine.Grasshopper.Objects.GH_IBHoMGeometry>
+    public class Param_BHoMGeometry : BHoMParam<Engine.Grasshopper.Objects.GH_IBHoMGeometry>, IGH_BakeAwareObject
     {
         /*******************************************/
         /**** Properties                        ****/
@@ -38,15 +42,42 @@ namespace BH.UI.Grasshopper.Parameters
 
         public override string TypeName { get; } = "BHoM Geometry";
 
+        public bool IsBakeCapable { get; } = true;
+
+        /***************************************************/
+        /**** IGH_BakeAwareObject methods               ****/
+        /***************************************************/
+
+        public void BakeGeometry(RhinoDoc doc, List<Guid> obj_ids)
+        {
+            foreach (Engine.Grasshopper.Objects.GH_IBHoMGeometry item in this.VolatileData.AllData(true))
+            {
+                Guid guid;
+                if (item.BakeGeometry(doc, null, out guid))
+                    obj_ids.Add(guid);
+            }
+        }
+
+        /*******************************************/
+
+        public void BakeGeometry(RhinoDoc doc, ObjectAttributes att, List<Guid> obj_ids)
+        {
+            foreach (Engine.Grasshopper.Objects.GH_IBHoMGeometry item in this.VolatileData.AllData(true))
+            {
+                Guid guid;
+                if (item.BakeGeometry(doc, att, out guid))
+                    obj_ids.Add(guid);
+            }
+        }
 
         /*******************************************/
         /**** Constructors                      ****/
         /*******************************************/
 
-        public Param_BHoMGeometry(): base("BHoM geometry", "BHoMGeo", "Represents a collection of generic BHoM geometries", "Params", "Geometry")
+        public Param_BHoMGeometry() : base("BHoM geometry", "BHoMGeo", "Represents a collection of generic BHoM geometries", "Params", "Geometry")
         {
         }
-        
+
         /*******************************************/
     }
 }

--- a/Grasshopper_UI/Components/Parameters/Param_BHoMObject.cs
+++ b/Grasshopper_UI/Components/Parameters/Param_BHoMObject.cs
@@ -22,11 +22,15 @@
 
 using BH.UI.Grasshopper.Properties;
 using BH.UI.Grasshopper.Templates;
+using Grasshopper.Kernel;
 using System;
+using Rhino;
+using Rhino.DocObjects;
+using System.Collections.Generic;
 
 namespace BH.UI.Grasshopper.Parameters
 {
-    public class Param_BHoMObject : BHoMParam<Engine.Grasshopper.Objects.GH_BHoMObject>
+    public class Param_BHoMObject : BHoMParam<Engine.Grasshopper.Objects.GH_BHoMObject>, IGH_BakeAwareObject
     {
         /*******************************************/
         /**** Properties                        ****/
@@ -38,6 +42,33 @@ namespace BH.UI.Grasshopper.Parameters
 
         public override string TypeName { get; } = "BHoM Object";
 
+        public bool IsBakeCapable { get; } = true;
+
+        /***************************************************/
+        /**** IGH_BakeAwareObject methods               ****/
+        /***************************************************/
+
+        public void BakeGeometry(RhinoDoc doc, List<Guid> obj_ids)
+        {
+            foreach (Engine.Grasshopper.Objects.GH_BHoMObject item in this.VolatileData.AllData(true))
+            {
+                Guid guid;
+                if (item.BakeGeometry(doc, null, out guid))
+                    obj_ids.Add(guid);
+            }
+        }
+
+        /*******************************************/
+
+        public void BakeGeometry(RhinoDoc doc, ObjectAttributes att, List<Guid> obj_ids)
+        {
+            foreach (Engine.Grasshopper.Objects.GH_BHoMObject item in this.VolatileData.AllData(true))
+            {
+                Guid guid;
+                if (item.BakeGeometry(doc, att, out guid))
+                    obj_ids.Add(guid);
+            }
+        }
 
         /*******************************************/
         /**** Constructors                      ****/
@@ -46,8 +77,10 @@ namespace BH.UI.Grasshopper.Parameters
         public Param_BHoMObject() : base("BHoM object", "BHoM", "Represents a collection of generic BHoM objects", "Params", "Primitive")
         {
         }
+
+        /*******************************************/
+
     }
 
-    /*******************************************/
 }
 

--- a/Grasshopper_UI/Components/Parameters/Param_IObject.cs
+++ b/Grasshopper_UI/Components/Parameters/Param_IObject.cs
@@ -23,11 +23,15 @@
 using BH.Engine.Grasshopper;
 using BH.UI.Grasshopper.Properties;
 using BH.UI.Grasshopper.Templates;
+using Grasshopper.Kernel;
 using System;
+using Rhino;
+using Rhino.DocObjects;
+using System.Collections.Generic;
 
 namespace BH.UI.Grasshopper.Parameters
 {
-    public class Param_IObject : BHoMParam<Engine.Grasshopper.Objects.GH_IObject>
+    public class Param_IObject : BHoMParam<Engine.Grasshopper.Objects.GH_IObject>, IGH_BakeAwareObject
     {
         /*******************************************/
         /**** Properties                        ****/
@@ -58,6 +62,33 @@ namespace BH.UI.Grasshopper.Parameters
             }
         }
 
+        public bool IsBakeCapable { get; } = true;
+
+        /***************************************************/
+        /**** IGH_BakeAwareObject methods               ****/
+        /***************************************************/
+
+        public void BakeGeometry(RhinoDoc doc, List<Guid> obj_ids)
+        {
+            foreach (Engine.Grasshopper.Objects.GH_IObject item in this.VolatileData.AllData(true))
+            {
+                Guid guid;
+                if (item.BakeGeometry(doc, null, out guid))
+                    obj_ids.Add(guid);
+            }
+        }
+
+        /*******************************************/
+
+        public void BakeGeometry(RhinoDoc doc, ObjectAttributes att, List<Guid> obj_ids)
+        {
+            foreach (Engine.Grasshopper.Objects.GH_IObject item in this.VolatileData.AllData(true))
+            {
+                Guid guid;
+                if (item.BakeGeometry(doc, att, out guid))
+                    obj_ids.Add(guid);
+            }
+        }
 
         /*******************************************/
         /**** Constructors                      ****/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #549

<!-- Add short description of what has been fixed -->

Did some quick digging after the workshop, and realised this was relatively simple, and actually already half-solved for geometry, so went ahead and just fixed it. Hope this does not derail anything @adecler , if so, please feel free to close/park.

- Making it possible to bake out BHoMGeometry
   - One half of this was actually already working. You actually were able to bake BHoMGeometry from a Data parameter. For this, Just needed to make the BHoMGeometry parameter bake aware as well.
- Adding Baking capability to the BHoMObject Goo and paramter
- Adding Baking capability to the IObjectGoo and paramter

### Test files
<!-- Link to test files to validate the proposed changes -->

Try baking some random BHoMObejcts and geometries. Should bake any BHoMObejct that is previewable, no others.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->