### PR TITLE
Use `IsRequired` instead of `HasDefaultValue` when deciding if a param is optional

### DIFF
--- a/Grasshopper_UI/Helpers/ToGH_Param.cs
+++ b/Grasshopper_UI/Helpers/ToGH_Param.cs
@@ -116,7 +116,7 @@ namespace BH.UI.Grasshopper
             param.Description = info.Description;
             param.Name = info.Name;
             param.NickName = info.Name;
-            param.Optional = info.HasDefaultValue;
+            param.Optional = !info.IsRequired;
 
             //TODO: Is it necessary to react to param.AttributesChanged ?
 

--- a/Grasshopper_UI/Helpers/ToGH_Param.cs
+++ b/Grasshopper_UI/Helpers/ToGH_Param.cs
@@ -125,7 +125,7 @@ namespace BH.UI.Grasshopper
 
             try
             {
-                if (info.HasDefaultValue)
+                if (info.HasDefaultValue && !info.IsRequired)
                     ((dynamic)param).SetPersistentData(info.DefaultValue.IToGoo());
             }
             catch { }


### PR DESCRIPTION
### NOTE: Depends on 
related to https://github.com/BHoM/BHoM_UI/pull/323
   
### Issues addressed by this PR

See https://github.com/BHoM/BHoM_UI/pull/323#pullrequestreview-508302276 for details


### Test files
Just make sure that a warning is created when a required input is not provided

