### PR TITLE
Grasshopper toolkit: Keeping flattening settings when replacing an input/output

### DIFF
--- a/Grasshopper_UI/CallerComponent/OncallerModified.cs
+++ b/Grasshopper_UI/CallerComponent/OncallerModified.cs
@@ -122,6 +122,8 @@ namespace BH.UI.Grasshopper.Templates
                 IGH_Param newParam = update.Param.ToGH_Param();
 
                 MoveLinks(oldParam, newParam);
+                newParam.DataMapping = oldParam.DataMapping;
+
                 Params.UnregisterInputParameter(oldParam);
                 Params.RegisterInputParam(newParam, index);
             }    

--- a/Grasshopper_UI/CallerComponent/OncallerModified.cs
+++ b/Grasshopper_UI/CallerComponent/OncallerModified.cs
@@ -190,7 +190,8 @@ namespace BH.UI.Grasshopper.Templates
                 IGH_Param newParam = update.Param.ToGH_Param();
 
                 // The Recipient property is still empty at this stage so we need to make sure recipient params are still finding their source 
-                newParam.NewInstanceGuid(oldParam.InstanceGuid); 
+                newParam.NewInstanceGuid(oldParam.InstanceGuid);
+                newParam.DataMapping = oldParam.DataMapping;
 
                 Params.UnregisterOutputParameter(oldParam);
                 Params.RegisterOutputParam(newParam, index);


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #562

See the issue for more details.

This was actually only happening when the input/output needed an upgrade. When replacing it, the links were copied over but not the flattening settings. 

### Test files
Reproduce the example provided in the issue and make sure it now works as expected.
