### PR TITLE
Fix BHoM vectors not convertible to GH vectors

### DIFF
--- a/Grasshopper_UI/Goos/GH_BakeableObject.cs
+++ b/Grasshopper_UI/Goos/GH_BakeableObject.cs
@@ -120,7 +120,7 @@ namespace BH.UI.Grasshopper.Goos
             {
                 if (Value == null)
                     target = default(Q);
-                if (target is IGH_GeometricGoo || target is GH_Transform || target is GH_Matrix)
+                if (target is IGH_GeometricGoo || target is GH_Transform || target is GH_Matrix || target is GH_Vector)
                     return Helpers.CastToGoo(m_RhinoGeometry as dynamic, ref target);
                 else
                     return Helpers.CastToGoo(Value as dynamic, ref target);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #571

<!-- Add short description of what has been fixed -->

Fix issue causing BHoM vectors not being converted to GH vectors. `GH_Vector` is not a `IGH_GeometricGoo`, so additional case needed to be added to check for that.

Before:

![image](https://user-images.githubusercontent.com/22005920/100464293-a1728d00-30cd-11eb-9c16-1eaeebc35ee9.png)


After:

![image](https://user-images.githubusercontent.com/22005920/100464309-a9cac800-30cd-11eb-99c3-d12e7108761e.png)


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->