### PR TITLE
Add new reference to CodeEditor_UI

### DIFF
--- a/Grasshopper_UI/Grasshopper_UI.csproj
+++ b/Grasshopper_UI/Grasshopper_UI.csproj
@@ -58,6 +58,7 @@
     </Reference>
     <Reference Include="CodeEditor_UI">
       <HintPath>C:\ProgramData\BHoM\Assemblies\CodeEditor_UI.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Data_Engine">
       <SpecificVersion>False</SpecificVersion>
@@ -71,6 +72,7 @@
     </Reference>
     <Reference Include="Dimensional_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Dimensional_oM.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Geometry_Engine">
       <SpecificVersion>False</SpecificVersion>
@@ -88,6 +90,7 @@
     </Reference>
     <Reference Include="Graphics_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Graphics_oM.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Grasshopper, Version=1.0.0.20, Culture=neutral, PublicKeyToken=dda4f5ec2cd80803, processorArchitecture=MSIL">
       <HintPath>..\packages\Grasshopper.0.9.76\lib\net35\Grasshopper.dll</HintPath>

--- a/Grasshopper_UI/Grasshopper_UI.csproj
+++ b/Grasshopper_UI/Grasshopper_UI.csproj
@@ -56,6 +56,9 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="CodeEditor_UI">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\CodeEditor_UI.dll</HintPath>
+    </Reference>
     <Reference Include="Data_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\ProgramData\BHoM\Assemblies\Data_Engine.dll</HintPath>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
https://github.com/BHoM/BHoM_UI/pull/359

   
### Issues addressed by this PR

With the RunCode component moved to its own dll, this PR keeps that component working by referencing the new dll.


### Test files
Just make sure the RunCode component is still working.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
@Fraser, I had to recompile the CSharp toolkit for the editor to open after I selected an item on the RunCode component. I found that a bit strange. Is the CSharp toolkit not distributed with the installer ?