### PR TITLE
Fix Access type update bug

### DIFF
--- a/Grasshopper_UI/CallerComponent/OnGHParamChanged.cs
+++ b/Grasshopper_UI/CallerComponent/OnGHParamChanged.cs
@@ -58,10 +58,18 @@ namespace BH.UI.Grasshopper.Templates
 
             // Updating Caller.InputParams based on the new Grasshopper parameter just received
             // We update the InputParams with the new type or name
-            Caller.UpdateInput(e.ParameterIndex, e.Parameter.NickName, e.Parameter.Type(Caller));
+            if (m_NotifyChanges)
+                Caller.UpdateInput(e.ParameterIndex, e.Parameter.NickName, e.Parameter.Type(Caller));
 
             return;
         }
+
+
+        /*******************************************/
+        /**** Private Fields                    ****/
+        /*******************************************/
+
+        protected bool m_NotifyChanges = true;
 
         /*******************************************/
     }

--- a/Grasshopper_UI/CallerComponent/OncallerModified.cs
+++ b/Grasshopper_UI/CallerComponent/OncallerModified.cs
@@ -53,6 +53,8 @@ namespace BH.UI.Grasshopper.Templates
             if (update == null)
                 return;
 
+            m_NotifyChanges = false;
+
             // Update the component details
             UpdateComponentDetails(update.ComponentUpdate);
 
@@ -65,6 +67,8 @@ namespace BH.UI.Grasshopper.Templates
             // Ask component to refresh
             Params.OnParametersChanged();
             ExpireSolution(true);
+
+            m_NotifyChanges = true;
         }
 
         /*******************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #518

If a parameter access type (i.e. item, list, tree) was changed by versioning, 
- the Grasshopper toolkit would correctly attempt to update the param 
- BUT would notify BHoM_UI that a parameter was changed in the middle of the process (more precisely when the links were moved from old param to new one)
- BHoM_UI would then take that info into account to recalculate the accessors based on the old input GH just sent.

Not sure if that is clear enough but the solution should be pretty straightforward to understand either way: Grasshopper should notify BHoM_UI of a change on the component ONLY when the user is making a change (e.g. renaming of a param), not when the component is updated because BHoM_UI asked it to. 

### Test files
You probably all have a script for that already given the screenshots you have made so far. If not, you can use what I did for myself:

#### Fake old code

```c#
public static CustomObject ItemToList(object obj, bool b = true)
{
    CustomObject custom = new CustomObject();
    custom.CustomData["data"] = obj.DeepClone();
    return custom;
}

public static CustomObject ListToItem(List<object> objects, bool b = true)
{
    CustomObject custom = new CustomObject();
    custom.CustomData["data"] = objects.ToList();
    return custom;
}
```

#### Fake new code

```c#
[PreviousVersion("4.1", "BH.Engine.Versioning.Compute.ItemToList(System.Object, System.Boolean)")]
public static CustomObject ItemToList(List<object> obj, bool b = true)
{
    CustomObject custom = new CustomObject();
    custom.CustomData["data"] = obj.ToList();
    return custom;
}

[PreviousVersion("4.1", "BH.Engine.Versioning.Compute.ListToItem(System.Collections.Generic.List<System.Object>, System.Boolean)")]
public static CustomObject ListToItem(object objects, bool b = true)
{
    CustomObject custom = new CustomObject();
    custom.CustomData["data"] = objects.DeepClone();
    return custom;
}
```

Just don't forget to also recompile the Versioning toolkit. If you place that code in a different location than me, make sure to correct the string in `PreviousVersion` accordingly.

