### PR TITLE
Fix bug where Simplify and Reverse disappear after copy/save

### DIFF
--- a/Grasshopper_UI/CallerComponent/OncallerModified.cs
+++ b/Grasshopper_UI/CallerComponent/OncallerModified.cs
@@ -127,6 +127,8 @@ namespace BH.UI.Grasshopper.Templates
 
                 MoveLinks(oldParam, newParam);
                 newParam.DataMapping = oldParam.DataMapping;
+                newParam.Simplify = oldParam.Simplify;
+                newParam.Reverse = oldParam.Reverse;
 
                 Params.UnregisterInputParameter(oldParam);
                 Params.RegisterInputParam(newParam, index);
@@ -196,6 +198,8 @@ namespace BH.UI.Grasshopper.Templates
                 // The Recipient property is still empty at this stage so we need to make sure recipient params are still finding their source 
                 newParam.NewInstanceGuid(oldParam.InstanceGuid);
                 newParam.DataMapping = oldParam.DataMapping;
+                newParam.Simplify = oldParam.Simplify;
+                newParam.Reverse = oldParam.Reverse;
 
                 Params.UnregisterOutputParameter(oldParam);
                 Params.RegisterOutputParam(newParam, index);


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #588

`Simplify` and `Reverse` options of input/output parameters were still disappearing after copy/pasting or saving a component. This PR should fix that.


### Test files
See https://github.com/BHoM/Grasshopper_Toolkit/issues/588#issuecomment-776704149

