### PR TITLE
Fix SetProperty ignoring type hint for the value input

### DIFF
--- a/Grasshopper_UI/Helpers/FromGoo.cs
+++ b/Grasshopper_UI/Helpers/FromGoo.cs
@@ -66,11 +66,7 @@ namespace BH.UI.Grasshopper
                 data = BH.Engine.Rhinoceros.Convert.IFromRhino(data);
 
             // Convert the data to an acceptable format
-            if (data is T)
-            {
-                return (T)data;
-            }
-            else if (hint != null)
+            if (hint != null)
             {
                 object result;
                 hint.Cast(RuntimeHelpers.GetObjectValue(data), out result);
@@ -78,6 +74,10 @@ namespace BH.UI.Grasshopper
 
                 if (data.GetType().Namespace.StartsWith("Rhino.Geometry"))
                     data = BH.Engine.Rhinoceros.Convert.IFromRhino(data);
+            }
+            else if (data is T)
+            {
+                return (T)data;
             }
             else if (data is IEnumerable)
             {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #605

For SetProperty, the type of the `value` input is object. Which means that the value was always returned without casting regardless of the hint. This is fine for most cases but was failing when a string needed to be parsed as a double for example. 

This PR fixes that by first looking at the hint.

### Test files
![image](https://user-images.githubusercontent.com/16853390/108182404-ee518700-7143-11eb-8109-760c7b5b1c45.png)


