### PR TITLE
Fixed lost links on old Explode update

### DIFF
--- a/Grasshopper_UI/CallerComponent/OncallerModified.cs
+++ b/Grasshopper_UI/CallerComponent/OncallerModified.cs
@@ -100,6 +100,10 @@ namespace BH.UI.Grasshopper.Templates
             if (match != null)
             {
                 MoveLinks(match, newParam);
+                newParam.DataMapping = match.DataMapping;
+                newParam.Simplify = match.Simplify;
+                newParam.Reverse = match.Reverse;
+
                 Params.UnregisterInputParameter(match);
             }
 

--- a/Grasshopper_UI/CallerComponent/OncallerModified.cs
+++ b/Grasshopper_UI/CallerComponent/OncallerModified.cs
@@ -170,6 +170,11 @@ namespace BH.UI.Grasshopper.Templates
             if (match != null)
             {
                 newParam.NewInstanceGuid(match.InstanceGuid);
+                newParam.DataMapping = match.DataMapping;
+                newParam.Simplify = match.Simplify;
+                newParam.Reverse = match.Reverse;
+
+                match.Recipients.Clear();
                 Params.UnregisterOutputParameter(match);
             }
 
@@ -201,6 +206,7 @@ namespace BH.UI.Grasshopper.Templates
                 newParam.Simplify = oldParam.Simplify;
                 newParam.Reverse = oldParam.Reverse;
 
+                oldParam.Recipients.Clear();
                 Params.UnregisterOutputParameter(oldParam);
                 Params.RegisterOutputParam(newParam, index);
             }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #560

This fixes the output wires disappearing when old Explode components are updated. 
New Explode components are working fine already as it was fixed in https://github.com/BHoM/Grasshopper_Toolkit/pull/530

I cannot fix the need to update the old Explode components though (similar to [this issue](https://github.com/BHoM/BHoM_UI/issues/277).

Note I also added the fix I had for disappearing flatten and simplify on updated outputs to the case where a ParamAdded is turned into an update (see PRs #564 & #603) since I just noticed it was not added there.

### Test files
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Grasshopper_Toolkit/%23560-FixLostLinkOnOldExplode.gh?csf=1&web=1&e=lodeDi

I have extracted the failing Explode from the test file provided in the issue since it was hidden inside a Cluster inside a large script (and obviously made sure it was still failing on the master). I added an Example of a new `Explode` component in the `This works fine` section to show that only old Explode components are failing and the fix done in PR https://github.com/BHoM/Grasshopper_Toolkit/pull/530 was doing its job correctly (i.e. no missing wires on updates).

