### PR TITLE
Make sure the component is executed when an input name is changed

### DIFF
--- a/Grasshopper_UI/CallerComponent/OnGHParamChanged.cs
+++ b/Grasshopper_UI/CallerComponent/OnGHParamChanged.cs
@@ -59,7 +59,13 @@ namespace BH.UI.Grasshopper.Templates
             // Updating Caller.InputParams based on the new Grasshopper parameter just received
             // We update the InputParams with the new type or name
             if (m_NotifyChanges)
+            {
+                bool newName = Caller.InputParams.Count > e.ParameterIndex && Caller.InputParams[e.ParameterIndex].Name != e.Parameter.NickName;
                 Caller.UpdateInput(e.ParameterIndex, e.Parameter.NickName, e.Parameter.Type(Caller));
+
+                if (newName)
+                    ExpireSolution(true); // It would be great to only expire the solution when the input menu closes to avoid doing it on each key stroke but there doesn't seem to be a way to access the menu
+            }
 
             return;
         }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #536

The component will be reran every time an input name is changed. 
A few things to note:

-  It is important that we only re-execute the component when the input name changes as `OnGHParamChanged` is also called when a wire is plugged.
- If you test by connecting a `CreateCustom` into an `Explode` component, don't be surprised that the `Explode` asks to be updated. This is a  necessary protective mechanism to avoid loosing wires when outputs change without the user expecting it. So I find testing this PR is easier by connecting a `CreateCustom` component in a `ToJson` component.
- The component will be re-executed on every keystroke. I would have liked to be able to detect when the input menu is closing to avoid that but I couldn't find a way to access it. This is not ideal but I guess too many updates is still better than none.

### Test files
See issue or comment above.

