### PR TITLE
Fix default values not assigned for Enumerables

### DIFF
--- a/Grasshopper_UI/Helpers/ToGH_Param.cs
+++ b/Grasshopper_UI/Helpers/ToGH_Param.cs
@@ -40,6 +40,8 @@ using BH.Adapter;
 using BH.UI.Grasshopper.Templates;
 using BH.Engine.Grasshopper;
 using Grasshopper.Kernel.Parameters.Hints;
+using Grasshopper.Kernel.Types;
+using Grasshopper.Kernel.Data;
 
 namespace BH.UI.Grasshopper
 {
@@ -124,11 +126,45 @@ namespace BH.UI.Grasshopper
             try
             {
                 if (info.HasDefaultValue && !info.IsRequired)
-                    ((dynamic)param).SetPersistentData(info.DefaultValue.IToGoo());
+                {
+                    var data = Helpers.IToGoo(info.DefaultValue as dynamic);
+                    SetPersistentData(param as dynamic, data as dynamic);
+                }
             }
             catch { }
 
             return param;
+        }
+
+
+        /*************************************/
+        /**** Private Methods             ****/
+        /*************************************/
+
+        private static void SetPersistentData<T>(GH_PersistentParam<T> param, IGH_Goo data) where T : class, IGH_Goo
+        {
+            param.SetPersistentData(data);
+        }
+
+        /*************************************/
+
+        private static void SetPersistentData<T>(GH_PersistentParam<T> param, List<IGH_Goo> data) where T : class, IGH_Goo
+        {
+            param.SetPersistentData(data.Cast<T>());
+        }
+
+        /*************************************/
+
+        private static void SetPersistentData<T>(GH_PersistentParam<T> param, GH_Structure<IGH_Goo> data) where T : class, IGH_Goo
+        {
+            param.SetPersistentData(data.Cast<T>());
+        }
+
+        /*************************************/
+
+        private static void SetPersistentData(object param, object data) 
+        {
+            // Do nothing;
         }
 
         /*******************************************/


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #528 

Default values of Enumerable properties where not set correctly in Grasshopper. See issue for more details.


### Test files
I used what was provided in the issue. Now working fine for me:

![image](https://user-images.githubusercontent.com/16853390/108592191-a3d04480-73a7-11eb-94cd-feb85d9800b9.png)

