### PR TITLE
Making sure wires are updated correctly when updating output of Explode

### DIFF
--- a/Grasshopper_UI/CallerComponent/OncallerModified.cs
+++ b/Grasshopper_UI/CallerComponent/OncallerModified.cs
@@ -210,6 +210,7 @@ namespace BH.UI.Grasshopper.Templates
                 newParam.Simplify = oldParam.Simplify;
                 newParam.Reverse = oldParam.Reverse;
 
+                MoveLinks(oldParam, newParam);
                 oldParam.Recipients.Clear();
                 Params.UnregisterOutputParameter(oldParam);
                 Params.RegisterOutputParam(newParam, index);


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #616 

Another fix on the dynamic side of the explode component. When output were updated (i.e. kept but edited instead of removed or added), the wires would look fine until the component was moved (see details on issue).

This PR makes sure the wires are migrated correctly to the new outputs.


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Grasshopper_Toolkit/%23616-OutputWireUpdateBug?csf=1&web=1&e=Cs26ln

Instructions are provided on the script: 
![image](https://user-images.githubusercontent.com/16853390/112118364-407c4100-8bf7-11eb-9275-d3d72f99da29.png)

