### PR TITLE
Set .NET framework version to 4.5.2

### DIFF
--- a/Grasshopper_Engine/Grasshopper_Engine.csproj
+++ b/Grasshopper_Engine/Grasshopper_Engine.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.Engine.Grasshopper</RootNamespace>
     <AssemblyName>Grasshopper_Engine</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/Grasshopper_Engine/app.config
+++ b/Grasshopper_Engine/app.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>

--- a/Grasshopper_UI/Grasshopper_UI.csproj
+++ b/Grasshopper_UI/Grasshopper_UI.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.UI.Grasshopper</RootNamespace>
     <AssemblyName>BH.UI.Grasshopper</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <TargetFrameworkProfile />
@@ -54,10 +54,6 @@
     </Reference>
     <Reference Include="BHoM_UI">
       <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM_UI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="CodeEditor_UI">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\CodeEditor_UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Data_Engine">

--- a/Grasshopper_UI/app.config
+++ b/Grasshopper_UI/app.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>


### PR DESCRIPTION
### Issues addressed by this PR
Set the .NET framework version of the projects in this toolkit to 4.5.2

### Test files
This PR will be reviewed by making sure that an installer can be produced from it. 