### PR TITLE
Mark non-curated components with a prototype label

### DIFF
--- a/Grasshopper_UI/CallerComponent/GH_Component.cs
+++ b/Grasshopper_UI/CallerComponent/GH_Component.cs
@@ -204,6 +204,15 @@ namespace BH.UI.Grasshopper.Templates
 
         /*******************************************/
 
+        public override void CreateAttributes()
+        {
+            m_attributes = new PrototypeAttribute(this);
+        }
+
+        /*******************************************/
+        /**** Private Fields                    ****/
+        /*******************************************/
+
         private static string m_CurrentLoadingDocument = "";
     }
 }

--- a/Grasshopper_UI/CallerComponent/OncallerModified.cs
+++ b/Grasshopper_UI/CallerComponent/OncallerModified.cs
@@ -82,6 +82,9 @@ namespace BH.UI.Grasshopper.Templates
                 Name = update.Name;
                 NickName = update.Name;
                 Description = update.Description;
+
+                if (m_attributes is PrototypeAttribute && Caller.SelectedItem != null)
+                    ((PrototypeAttribute)m_attributes).Visible = Caller.SelectedItem.IsPrototype();
             }
         }
 

--- a/Grasshopper_UI/CustomAttributes/PrototypeAttribute.cs
+++ b/Grasshopper_UI/CustomAttributes/PrototypeAttribute.cs
@@ -1,0 +1,147 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Attributes;
+using BH.oM.Base;
+using BH.UI.Grasshopper.Templates;
+using BH.UI.Base;
+using BH.UI.Base.Components;
+using Grasshopper.GUI.Canvas;
+using System.Drawing;
+using Grasshopper.GUI;
+using System.Drawing.Drawing2D;
+
+namespace BH.UI.Grasshopper.Components
+{
+    public class PrototypeAttribute : GH_ComponentAttributes​
+    {
+        /*******************************************/
+        /**** Properties                        ****/
+        /*******************************************/
+
+        public bool Visible { get; set; } = false;
+
+
+        /*******************************************/
+        /**** Constructors                      ****/
+        /*******************************************/
+
+        public PrototypeAttribute(GH_Component owner) : base(owner) { }
+
+
+        /*******************************************/
+        /**** Override Methods                  ****/
+        /*******************************************/
+
+        protected override void Layout()
+        {
+            base.Layout();
+
+            if (Visible)
+            {
+                m_LabelBounds = new RectangleF(Bounds.X, Bounds.Bottom - 1, Bounds.Width, m_LabelHeight);
+                Bounds = new RectangleF(Bounds.X, Bounds.Y, Bounds.Width, Bounds.Height + m_LabelHeight);
+            }
+        }
+
+        /*******************************************/
+
+        protected override void Render(GH_Canvas canvas, Graphics graphics, GH_CanvasChannel channel)
+        {
+            base.Render(canvas, graphics, channel);
+
+            // Only draw if visible and on hte correct channel
+            if (!Visible || channel != GH_CanvasChannel.Objects)
+                return;
+
+            // Define the colour of the render to match teh component's borders
+            Color colour;
+            if (Selected)
+                colour = Color.FromArgb(0, 50, 0);
+            else switch (Owner.RuntimeMessageLevel)
+            {
+                case GH_RuntimeMessageLevel.Warning:
+                    colour = Color.FromArgb(80, 10, 0);
+                    break;
+                case GH_RuntimeMessageLevel.Error:
+                    colour = Color.FromArgb(60, 0, 0);
+                    break;
+                default:
+                    colour = Color.FromArgb(50, 50, 50);
+                    break;
+            }
+               
+            // Define render parameters
+            Font font = GH_FontServer.Small;
+            Pen linePen = new Pen(colour);
+            linePen.Width = m_LabelHeight / 3;
+            string labelText = "Prototype";
+            SizeF stringSize = GH_FontServer.MeasureString(labelText, font);
+            stringSize.Height -= 2;
+
+            // Draw the label
+            graphics.DrawString("Prototype", font, new SolidBrush(colour), m_LabelBounds, GH_TextRenderingConstants.CenterCenter);
+
+            // Decide if we render strips or a simple line around the label
+            if (m_DrawStrips)
+            {
+                // Define region to draw into
+                Region clip = new Region(new RectangleF(m_LabelBounds.Location, new SizeF(m_LabelBounds.Width, m_LabelBounds.Height + 1)));
+                clip.Exclude(new RectangleF(
+                    new PointF(m_LabelBounds.X + (m_LabelBounds.Width - stringSize.Width) / 2, m_LabelBounds.Y + (m_LabelBounds.Height - stringSize.Height) / 2),
+                    stringSize));
+                graphics.SetClip(clip, CombineMode.Replace);
+
+                // Draw the strips
+                Pen stripPen = new Pen(colour, m_LabelHeight / 3);
+                for (int dx = -m_LabelHeight / 2; dx < m_LabelBounds.Width; dx += m_LabelHeight)
+                    graphics.DrawLine(stripPen,
+                        new Point((int)m_LabelBounds.X + dx, (int)m_LabelBounds.Y + (int)m_LabelBounds.Height + 2),
+                        new Point((int)m_LabelBounds.X + dx + m_LabelHeight + 4, (int)m_LabelBounds.Y - 2));
+
+                // Clear the region filter
+                graphics.ResetClip();
+            }
+            else
+            {
+                // Draw the lines aroudn the label
+                float y = m_LabelBounds.Y + m_LabelBounds.Height / 2;
+                graphics.DrawLine(linePen, m_LabelBounds.X + 1, y, m_LabelBounds.X + (m_LabelBounds.Width - stringSize.Width) / 2 - 4, y);
+                graphics.DrawLine(linePen, m_LabelBounds.X + (m_LabelBounds.Width - stringSize.Width) / 2 + stringSize.Width + 4, y, m_LabelBounds.X + m_LabelBounds.Width - 1, y);
+            }
+        }
+
+        /*******************************************/
+        /**** Private Fields                    ****/
+        /*******************************************/
+
+        RectangleF m_LabelBounds;
+        int m_LabelHeight = 10;
+        bool m_DrawStrips = true;
+
+        /*******************************************/
+    }
+}
+
+

--- a/Grasshopper_UI/CustomAttributes/PrototypeAttribute.cs
+++ b/Grasshopper_UI/CustomAttributes/PrototypeAttribute.cs
@@ -75,23 +75,25 @@ namespace BH.UI.Grasshopper.Components
             if (!Visible || channel != GH_CanvasChannel.Objects)
                 return;
 
-            // Define the colour of the render to match teh component's borders
             Color colour;
-            if (Selected)
-                colour = Color.FromArgb(0, 50, 0);
-            else switch (Owner.RuntimeMessageLevel)
+            try
             {
-                case GH_RuntimeMessageLevel.Warning:
-                    colour = Color.FromArgb(80, 10, 0);
-                    break;
-                case GH_RuntimeMessageLevel.Error:
-                    colour = Color.FromArgb(60, 0, 0);
-                    break;
-                default:
-                    colour = Color.FromArgb(50, 50, 50);
-                    break;
+                // Define the colour of the render to match teh component's borders
+                GH_Palette palette = GH_CapsuleRenderEngine.GetImpliedPalette(this.Owner);
+                if (palette == GH_Palette.Normal && !this.Owner.IsPreviewCapable)
+                {
+                    palette = GH_Palette.Hidden;
+                }
+                GH_PaletteStyle style = GH_CapsuleRenderEngine.GetImpliedStyle(palette, this.Selected, this.Owner.Locked, this.Owner.Hidden);
+
+                colour = style.Edge;
             }
-               
+            catch (Exception)
+            {
+                //Fallback to using black if the above crashes for any reason
+                colour = Color.Black;
+            }
+  
             // Define render parameters
             Font font = GH_FontServer.Small;
             Pen linePen = new Pen(colour);

--- a/Grasshopper_UI/Grasshopper_UI.csproj
+++ b/Grasshopper_UI/Grasshopper_UI.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Components\Parameters\Param_BHoMAdapter.cs" />
     <Compile Include="Components\Parameters\Param_Variable.cs" />
     <Compile Include="Components\UI\UnitTest.cs" />
+    <Compile Include="CustomAttributes\PrototypeAttribute.cs" />
     <Compile Include="Global\WireInfo.cs" />
     <Compile Include="Components\UI\Cluster2Node.cs" />
     <Compile Include="Goos\GH_BakeableObject.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
https://github.com/BHoM/BHoM_Engine/pull/2590

   
### Issues addressed by this PR

Closes #631

Requires the file containing the list of curated assemblies for testing. @FraserGreenroyd , I have placed your file containing the list of dlls here: `C:\ProgramData\BHoM\Settings\IncludedDlls.txt`


### Test files
Any components can be used for testing as long as some are part of the installer and some are not. Here's an example of what to expect:

![image](https://user-images.githubusercontent.com/16853390/128672649-26623029-d09a-4f0d-97ec-3513f7239043.png)

### Additional comments
The yellow background behind the strips was a bit of an issue due to the rounded edges of the component so I didn't include it. Personally, I actually prefer it that way as it clashes less visually. I found that matching the color of the strips with the color of the component's border had the best visual effect. 