### PR TITLE
Disabling display of message on dropdown until a solution that works for Rhino7 is found

### DIFF
--- a/Grasshopper_UI/CustomAttributes/PrototypeValueListAttribute.cs
+++ b/Grasshopper_UI/CustomAttributes/PrototypeValueListAttribute.cs
@@ -78,14 +78,14 @@ namespace BH.UI.Grasshopper.Components
             if(Visible)
                 this.RenderPrototypeLabel(graphics, m_LabelBounds, false, false, true);
 
-            string message = (this.Owner as CallerValueList)?.Message;
+            //string message = (this.Owner as CallerValueList)?.Message;
 
-            if (!string.IsNullOrWhiteSpace(message))
-            {
-                GH_PaletteStyle impliedStyle = GH_CapsuleRenderEngine.GetImpliedStyle(GH_Palette.Normal, this.Selected, base.Owner.Locked, base.Owner.Hidden);
-                GH_Capsule capsule = GH_Capsule.CreateCapsule(Bounds, GH_Palette.Normal);
-                capsule.RenderEngine.RenderMessage(graphics, message, impliedStyle);
-            }
+            //if (!string.IsNullOrWhiteSpace(message))
+            //{
+            //    GH_PaletteStyle impliedStyle = GH_CapsuleRenderEngine.GetImpliedStyle(GH_Palette.Normal, this.Selected, base.Owner.Locked, base.Owner.Hidden);
+            //    GH_Capsule capsule = GH_Capsule.CreateCapsule(Bounds, GH_Palette.Normal);
+            //    capsule.RenderEngine.RenderMessage(graphics, message, impliedStyle);
+            //}
         }
 
         /*******************************************/


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #641

<!-- Add short description of what has been fixed -->

Disabling feature added in https://github.com/BHoM/Grasshopper_Toolkit/pull/640 until a solution working for all versions of rhino can be found in https://github.com/BHoM/Grasshopper_Toolkit/issues/642

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->