### PR TITLE
Displaying message on dropdown components

### DIFF
--- a/Grasshopper_UI/CustomAttributes/PrototypeValueListAttribute.cs
+++ b/Grasshopper_UI/CustomAttributes/PrototypeValueListAttribute.cs
@@ -174,9 +174,10 @@ namespace BH.UI.Grasshopper.Components
                     CallerValueList owner = (this.Owner as CallerValueList);
                     if (owner != null && owner.IsWarningMessage && !Visible)
                     {
-                        palette = GH_Palette.Warning;
-                        style = GH_CapsuleRenderEngine.GetImpliedStyle(palette, this.Selected, this.Owner.Locked, this.Owner.Hidden);
-                        fill = style.Fill;
+                        if (this.Selected)
+                            fill = Color.FromArgb(210, 230, 25);
+                        else
+                            fill = Color.FromArgb(241, 175, 29);
                     }
                 }
 

--- a/Grasshopper_UI/Render/RenderPrototypeLabel.cs
+++ b/Grasshopper_UI/Render/RenderPrototypeLabel.cs
@@ -78,6 +78,8 @@ namespace BH.UI.Grasshopper
             // Decide if we render strips or a simple line around the label
             if (drawStrips)
             {
+
+
                 //Base capsule
                 GH_Capsule capsule = GH_Capsule.CreateCapsule(attributes.Bounds, palette);
                 capsule.SetJaggedEdges(jaggedLeft, jaggedRight);
@@ -94,6 +96,9 @@ namespace BH.UI.Grasshopper
                 graphics.FillRectangle(new SolidBrush(yellowBackground), botRectangle);
 
                 //Define the box around the text to cull
+                int zoomFadeMedium = GH_Canvas.ZoomFadeLow;
+
+                
                 float textHeight = stringSize.Height;
                 float textWidth = stringSize.Width;
                 stringSize.Width = Math.Max(textWidth, textHeight * 6.1f);  //To exactly hit the corners of the box, for 45degree angle, box should have aspectratio 1:6
@@ -102,7 +107,8 @@ namespace BH.UI.Grasshopper
                     new PointF(labelBounds.X + (labelBounds.Width - stringSize.Width) / 2, labelBounds.Y + (labelBounds.Height - stringSize.Height
                     ) / 2),
                     stringSize);
-                clip.Exclude(textBox);
+                if (zoomFadeMedium > 5)
+                    clip.Exclude(textBox);
                 graphics.SetClip(clip, CombineMode.Replace);
 
                 //Set up parameters for stripes
@@ -128,11 +134,13 @@ namespace BH.UI.Grasshopper
                 // Clear the region filter
                 graphics.ResetClip();
 
-                RectangleF textRenderBounds = labelBounds;
-                textRenderBounds.Y -= 1;
-                // Draw the label
-                graphics.DrawString("Prototype", font, new SolidBrush(colour), textRenderBounds, GH_TextRenderingConstants.CenterCenter);
-
+                if (zoomFadeMedium > 5)
+                {
+                    RectangleF textRenderBounds = labelBounds;
+                    textRenderBounds.Y -= 1;
+                    // Draw the label
+                    graphics.DrawString("Prototype", font, new SolidBrush(Color.FromArgb(zoomFadeMedium, colour)), textRenderBounds, GH_TextRenderingConstants.CenterCenter);
+                }
                 float zoom = graphics.Transform.Elements[0];
                 capsule.RenderEngine.RenderOutlines(graphics, zoom, style);
             }

--- a/Grasshopper_UI/Templates/CallerValueList.cs
+++ b/Grasshopper_UI/Templates/CallerValueList.cs
@@ -55,6 +55,8 @@ namespace BH.UI.Grasshopper.Templates
 
         public string Message { get; set; } = "";
 
+        public bool IsWarningMessage { get; set; } = false;
+
 
         /*******************************************/
         /**** Constructors                      ****/
@@ -94,7 +96,14 @@ namespace BH.UI.Grasshopper.Templates
                     if (Caller.SelectedItem is string)
                     {
                         ((PrototypeValueListAttribute)m_attributes).Visible = Engine.Library.Query.IsPrototype(Caller.SelectedItem as string);
-                        Message = "Confidence: " + Engine.Library.Query.Confidence(Caller.SelectedItem as string).ToString();
+                        BH.oM.Data.Library.Confidence confidence = Engine.Library.Query.Confidence(Caller.SelectedItem as string);
+
+                        if (confidence == oM.Data.Library.Confidence.Undefined || confidence == oM.Data.Library.Confidence.None || confidence == oM.Data.Library.Confidence.Low)
+                            IsWarningMessage = true;
+                        else
+                            IsWarningMessage = false;
+
+                        Message = "Confidence: " + confidence.ToString();
                     }
 
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #642 

<!-- Add short description of what has been fixed -->

Adding message display for dropdown components back in, after being lifted out in #643 

Made a tweak to allow for 2 levels of colouring of the text, to enable lower levels of confidence to stand out a bit more.

Can roll this back if it looks to intrusive:

![image](https://user-images.githubusercontent.com/22005920/138688843-f881eafe-c0ce-47a6-9ff3-28502bbc5b94.png)


For Prototype components, I went with always displaying the standard colour, as displaying both the prototype label and a warning colour for the message became a bit much, and the Prototype labels are doing the job of warning the user of the content:

![image](https://user-images.githubusercontent.com/22005920/138689096-413b805a-43ed-4b4f-8e14-2b0e8e2dbd28.png)


Glad to get any feedback on this, especially on the warning colour of the message.

Have tested with Grasshopper for rhino 5,6 and 7 and all work my end.

To test the normal look https://github.com/BHoM/BHoM_Datasets/pull/105 can be used.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->