### PR TITLE
Adding UI Setting with ability to disable wire menu

### DIFF
--- a/Grasshopper_Engine/Grasshopper_Engine.csproj
+++ b/Grasshopper_Engine/Grasshopper_Engine.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/Grasshopper_Engine/Grasshopper_Engine.csproj
+++ b/Grasshopper_Engine/Grasshopper_Engine.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -143,6 +143,12 @@
     <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Versioning_41.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Grasshopper_oM\Grasshopper_oM.csproj">
+      <Project>{d18cbd7a-566d-48f7-afae-62f1e2aa0536}</Project>
+      <Name>Grasshopper_oM</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\RhinoCommon.5.12.50810.13095\build\net35\RhinoCommon.targets" Condition="Exists('..\packages\RhinoCommon.5.12.50810.13095\build\net35\RhinoCommon.targets')" />

--- a/Grasshopper_Toolkit.sln
+++ b/Grasshopper_Toolkit.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Grasshopper_UI", "Grasshopp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Grasshopper_Engine", "Grasshopper_Engine\Grasshopper_Engine.csproj", "{DDE47285-E709-4752-9AFD-6FA03B449364}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Grasshopper_oM", "Grasshopper_oM\Grasshopper_oM.csproj", "{D18CBD7A-566D-48F7-AFAE-62F1E2AA0536}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +28,12 @@ Global
 		{DDE47285-E709-4752-9AFD-6FA03B449364}.Debug64|Any CPU.Build.0 = Debug|Any CPU
 		{DDE47285-E709-4752-9AFD-6FA03B449364}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DDE47285-E709-4752-9AFD-6FA03B449364}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D18CBD7A-566D-48F7-AFAE-62F1E2AA0536}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D18CBD7A-566D-48F7-AFAE-62F1E2AA0536}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D18CBD7A-566D-48F7-AFAE-62F1E2AA0536}.Debug64|Any CPU.ActiveCfg = Debug|Any CPU
+		{D18CBD7A-566D-48F7-AFAE-62F1E2AA0536}.Debug64|Any CPU.Build.0 = Debug|Any CPU
+		{D18CBD7A-566D-48F7-AFAE-62F1E2AA0536}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D18CBD7A-566D-48F7-AFAE-62F1E2AA0536}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Grasshopper_UI/Global/GlobalSearch.cs
+++ b/Grasshopper_UI/Global/GlobalSearch.cs
@@ -63,7 +63,7 @@ namespace BH.UI.Grasshopper.Global
             UpdateSettingsFromFile();
 
             // Watch for changes of the settings file
-            string settingsFolder = Path.GetFullPath(Path.Combine(BH.Engine.Reflection.Query.BHoMFolder(), @"..\Settings"));
+            string settingsFolder = Path.GetFullPath(Path.Combine(BH.Engine.Base.Query.BHoMFolder(), @"..\Settings"));
             m_Watcher = new FileSystemWatcher(settingsFolder, "Grasshopper.cfg");
             m_Watcher.EnableRaisingEvents = true;
             m_Watcher.Changed += (sender, e) => UpdateSettingsFromFile();

--- a/Grasshopper_UI/Grasshopper_UI.csproj
+++ b/Grasshopper_UI/Grasshopper_UI.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug64</Configuration>
@@ -363,6 +363,10 @@
       <Project>{dde47285-e709-4752-9afd-6fa03b449364}</Project>
       <Name>Grasshopper_Engine</Name>
       <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Grasshopper_oM\Grasshopper_oM.csproj">
+      <Project>{d18cbd7a-566d-48f7-afae-62f1e2aa0536}</Project>
+      <Name>Grasshopper_oM</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Grasshopper_UI/Grasshopper_UI.csproj
+++ b/Grasshopper_UI/Grasshopper_UI.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug64</Configuration>

--- a/Grasshopper_oM/Grasshopper_oM.csproj
+++ b/Grasshopper_oM/Grasshopper_oM.csproj
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D18CBD7A-566D-48F7-AFAE-62F1E2AA0536}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BH.oM.Grasshopper</RootNamespace>
+    <AssemblyName>Grasshopper_oM</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="BHoM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UISettings.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/Grasshopper_oM/Grasshopper_oM.csproj
+++ b/Grasshopper_oM/Grasshopper_oM.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -34,6 +34,7 @@
     <Reference Include="BHoM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Grasshopper_oM/Properties/AssemblyInfo.cs
+++ b/Grasshopper_oM/Properties/AssemblyInfo.cs
@@ -1,4 +1,26 @@
-﻿using System.Reflection;
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/Grasshopper_oM/Properties/AssemblyInfo.cs
+++ b/Grasshopper_oM/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Grasshopper_oM")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Grasshopper_oM")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("d18cbd7a-566d-48f7-afae-62f1e2aa0536")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("5.0.0.0")]
+[assembly: AssemblyFileVersion("5.0.0.0")]

--- a/Grasshopper_oM/Properties/AssemblyInfo.cs
+++ b/Grasshopper_oM/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -56,3 +56,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("5.0.0.0")]
 [assembly: AssemblyFileVersion("5.0.0.0")]
+

--- a/Grasshopper_oM/UISettings.cs
+++ b/Grasshopper_oM/UISettings.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Base;
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/Grasshopper_oM/UISettings.cs
+++ b/Grasshopper_oM/UISettings.cs
@@ -1,0 +1,16 @@
+﻿using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Grasshopper
+{
+    [Description("Settings for the Grasshopper UI.")]
+    public class UISettings : BHoMObject, ISettings
+    {
+        public virtual bool UseWireMenu { get; set; } = true;
+    }
+}

--- a/Grasshopper_oM/UISettings.cs
+++ b/Grasshopper_oM/UISettings.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -36,3 +36,4 @@ namespace BH.oM.Grasshopper
         public virtual bool UseWireMenu { get; set; } = true;
     }
 }
+


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #645

As discussed, no fancy menu at the moment. But a fairly simple way to set Grasshopper UI settings using the existing infrastructure for settings.

### Test files
Simply create those components on the canvas and toggle the boolean to activate or deactivate the wire menu:

![GrasshopperSettings_Demo](https://user-images.githubusercontent.com/16853390/142148337-001f7225-19a5-4033-aad4-120f73f1684c.gif)
