### PR TITLE
Add better support for updating components from Create method to AutoCreate

### DIFF
--- a/Grasshopper_UI/CallerComponent/OncallerModified.cs
+++ b/Grasshopper_UI/CallerComponent/OncallerModified.cs
@@ -98,7 +98,7 @@ namespace BH.UI.Grasshopper.Templates
 
             // If there is already a param with the same name, delete it but keep the wire connections
             // Same approach as `UpdateInput(ParamUpdated update)` but with index provided by ParamAdded
-            IGH_Param match = Params.Input.Find(x => x.Name == update.Name);
+            IGH_Param match = Params.Input.Find(x => x.Name.ToLower() == update.Name.ToLower());
             if (match != null)
             {
                 MoveLinks(match, newParam);
@@ -116,7 +116,7 @@ namespace BH.UI.Grasshopper.Templates
 
         protected virtual void UpdateInput(ParamRemoved update)
         {
-            IGH_Param match = Params.Input.Find(x => x.Name == update.Name);
+            IGH_Param match = Params.Input.Find(x => x.Name.ToLower() == update.Name.ToLower());
             if (match != null)
                 Params.UnregisterInputParameter(match);
         }
@@ -125,7 +125,7 @@ namespace BH.UI.Grasshopper.Templates
 
         protected virtual void UpdateInput(ParamUpdated update)
         {
-            int index = Params.Input.FindIndex(x => x.Name == update.Name);
+            int index = Params.Input.FindIndex(x => x.Name.ToLower() == update.Name.ToLower());
             if (index >= 0)
             {
                 IGH_Param oldParam = Params.Input[index];


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

Done in support of https://github.com/BHoM/BHoM_Engine/pull/2738/files but does not require that to compile.

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Add short description of what has been fixed -->

Noticing while removing several old create methods in https://github.com/BHoM/BHoM_Engine/pull/2738/files that some of them did not match up to the autogenerated creates. This seem to have to do with keys not identified on the side of GH.

Adding ToLower when scanning the properties seem to have fixed that issue. @adecler good for you to check this and that it does not go against the intention of the method

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->