### PR TITLE
Caching of preview meshes to improve performance

### DIFF
--- a/Grasshopper_UI/Goos/GH_BakeableObject.cs
+++ b/Grasshopper_UI/Goos/GH_BakeableObject.cs
@@ -185,7 +185,7 @@ namespace BH.UI.Grasshopper.Goos
 
                 if (m_PreviewMesh == null)
                 {
-                    m_IsMeshPreviewable = false;    //If no mesh could be extracted, set flag as no required to check again for the same geometry
+                    m_IsMeshPreviewable = false;    //If no mesh could be extracted, set flag as not required to check again for the same geometry
                     return;
                 }
             }

--- a/Grasshopper_UI/Grasshopper_UI.csproj
+++ b/Grasshopper_UI/Grasshopper_UI.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug64</Configuration>
@@ -200,6 +200,7 @@
     <Compile Include="Hints\EnumHint.cs" />
     <Compile Include="Hints\IGeometryHint.cs" />
     <Compile Include="Hints\TypeHint.cs" />
+    <Compile Include="Render\CreatePreviewMesh.cs" />
     <Compile Include="Render\RenderPrototypeLabel.cs" />
     <Compile Include="Render\RenderColour.cs" />
     <Compile Include="Render\RenderMaterial.cs" />

--- a/Grasshopper_UI/Render/CreatePreviewMesh.cs
+++ b/Grasshopper_UI/Render/CreatePreviewMesh.cs
@@ -1,0 +1,192 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using RHG = Rhino.Geometry;
+using Rhino.Display;
+using Grasshopper.Kernel;
+using System;
+using BH.oM.Base.Attributes;
+using System.Collections.Generic;
+using BH.oM.Geometry;
+using System.Drawing;
+using BH.Engine.Rhinoceros;
+
+namespace BH.UI.Grasshopper
+{
+    public static partial class Render
+    {
+        /***************************************************/
+        /**** Public Methods  - Interfaces              ****/
+        /***************************************************/
+
+        public static RHG.Mesh ICreatePreviewMesh(this object obj, RHG.MeshingParameters parameters)
+        {
+            if (obj == null)
+            {
+                return null;
+            }
+            if (parameters == null)
+                parameters = RHG.MeshingParameters.Default;
+
+            try
+            {
+                return CreatePreviewMesh(obj as dynamic, parameters);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /***************************************************/
+
+        public static RHG.Mesh CreatePreviewMesh(this List<object> geometry, RHG.MeshingParameters parameters)
+        {
+            RHG.Mesh mesh = new RHG.Mesh();
+            foreach (object geo in geometry)
+            {
+                RHG.Mesh itemMesh = CreatePreviewMesh(geo as dynamic, parameters);
+                if (itemMesh != null)
+                    mesh.Append(itemMesh);
+            }
+            return mesh;
+        }
+
+
+        /***************************************************/
+        /**** Private Methods  - Fallback               ****/
+        /***************************************************/
+
+        private static RHG.Mesh CreatePreviewMesh(this object fallback, RHG.MeshingParameters parameters)
+        {
+            // fallback in case no method is found for the provided runtime type
+            return null;
+        }
+
+
+        /***************************************************/
+        /**** Public Methods  - Surfaces                ****/
+        /***************************************************/
+
+        public static RHG.Mesh CreatePreviewMesh(RHG.Extrusion surface, RHG.MeshingParameters parameters)
+        {
+            return CreatePreviewMesh(surface.ToBrep(), parameters);
+        }
+
+        /***************************************************/
+
+        public static RHG.Mesh CreatePreviewMesh(RHG.NurbsSurface surface, RHG.MeshingParameters parameters)
+        {
+            return CreatePreviewMesh(surface.ToBrep(), parameters);
+        }
+
+        /***************************************************/
+
+        public static RHG.Mesh CreatePreviewMesh(RHG.Brep brep, RHG.MeshingParameters parameters)
+        {
+            RHG.Mesh[] array = RHG.Mesh.CreateFromBrep(brep, parameters);
+            if (array == null)
+            {
+                return new RHG.Mesh();
+            }
+            if (array.Length == 1)
+            {
+                return array[0];
+            }
+            RHG.Mesh mesh = new RHG.Mesh();
+            foreach (var faceMesh in array)
+            {
+                mesh.Append(faceMesh);
+            }
+            return mesh;
+        }
+
+        /***************************************************/
+
+        public static RHG.Mesh CreatePreviewMesh(RHG.Surface surface, RHG.MeshingParameters parameters)
+        {
+            return CreatePreviewMesh(surface.ToBrep(), parameters);
+        }
+
+
+        /***************************************************/
+        /**** Public Methods - Solids                   ****/
+        /***************************************************/
+
+        public static RHG.Mesh CreatePreviewMesh(RHG.Cone cone, RHG.MeshingParameters parameters)
+        {
+            return CreatePreviewMesh(cone.ToBrep(true), parameters);
+        }
+
+        /***************************************************/
+
+        public static RHG.Mesh CreatePreviewMesh(RHG.Cylinder cylinder, RHG.MeshingParameters parameters)
+        {
+            return CreatePreviewMesh(cylinder.ToBrep(cylinder.IsFinite, cylinder.IsFinite), parameters);
+        }
+
+        /***************************************************/
+
+        public static RHG.Mesh CreatePreviewMesh(RHG.Sphere sphere, RHG.MeshingParameters parameters)
+        {
+            return CreatePreviewMesh(sphere.ToBrep(), parameters);
+        }
+
+        /***************************************************/
+
+        public static RHG.Mesh CreatePreviewMesh(RHG.Torus torus, RHG.MeshingParameters parameters)
+        {
+            return CreatePreviewMesh(torus.ToRevSurface().ToBrep(), parameters);
+        }
+
+        /***************************************************/
+
+        public static RHG.Mesh CreatePreviewMesh(RHG.Box box, RHG.MeshingParameters parameters)
+        {
+            return CreatePreviewMesh(box.ToBrep(), parameters);
+        }
+
+        /***************************************************/
+        /**** Public Methods  - Mesh                    ****/
+        /***************************************************/
+
+        public static RHG.Mesh CreatePreviewMesh(RHG.Mesh mesh, RHG.MeshingParameters parameters)
+        {
+            return mesh;
+        }
+
+
+        /***************************************************/
+        /**** Public Methods  - Miscellanea             ****/
+        /***************************************************/
+
+        public static RHG.Mesh CreatePreviewMesh(RHG.BoundingBox bbBox, RHG.MeshingParameters parameters)
+        {
+            return CreatePreviewMesh(bbBox.ToBrep(), parameters);
+        }
+
+        /***************************************************/
+    }
+}
+
+
+

--- a/Grasshopper_UI/Render/CreatePreviewMesh.cs
+++ b/Grasshopper_UI/Render/CreatePreviewMesh.cs
@@ -41,9 +41,8 @@ namespace BH.UI.Grasshopper
         public static RHG.Mesh ICreatePreviewMesh(this object obj, RHG.MeshingParameters parameters)
         {
             if (obj == null)
-            {
                 return null;
-            }
+
             if (parameters == null)
                 parameters = RHG.MeshingParameters.Default;
 
@@ -105,13 +104,11 @@ namespace BH.UI.Grasshopper
         {
             RHG.Mesh[] array = RHG.Mesh.CreateFromBrep(brep, parameters);
             if (array == null)
-            {
                 return new RHG.Mesh();
-            }
+
             if (array.Length == 1)
-            {
                 return array[0];
-            }
+
             RHG.Mesh mesh = new RHG.Mesh();
             foreach (var faceMesh in array)
             {

--- a/Grasshopper_UI/Render/RenderMaterial.cs
+++ b/Grasshopper_UI/Render/RenderMaterial.cs
@@ -36,8 +36,8 @@ namespace BH.UI.Grasshopper
         {
             Color pColour = GH.Instances.ActiveCanvas.Document.PreviewColour;
             Color ghColour = material.Diffuse;
-            if (ghColour.R == pColour.R & // If the color sent by PreviewArgs is the default object PreviewColour
-                ghColour.G == pColour.G &
+            if (ghColour.R == pColour.R && // If the color sent by PreviewArgs is the default object PreviewColour
+                ghColour.G == pColour.G &&
                 ghColour.B == pColour.B) // Excluding Alpha channel from comparison
             {
                 double transparency = (255 - custom.A) / (double)255;
@@ -58,8 +58,8 @@ namespace BH.UI.Grasshopper
 
             Color pColour = GH.Instances.ActiveCanvas.Document.PreviewColour;
             Color ghColour = material.Diffuse;
-            if (ghColour.R == pColour.R & // If the color sent by PreviewArgs is the default object PreviewColour
-                ghColour.G == pColour.G &
+            if (ghColour.R == pColour.R && // If the color sent by PreviewArgs is the default object PreviewColour
+                ghColour.G == pColour.G &&
                 ghColour.B == pColour.B) // Excluding Alpha channel from comparison
             {
                 return custom;

--- a/Grasshopper_UI/Render/RenderMaterial.cs
+++ b/Grasshopper_UI/Render/RenderMaterial.cs
@@ -50,6 +50,27 @@ namespace BH.UI.Grasshopper
         }
 
         /***************************************************/
+
+        public static DisplayMaterial RenderMaterial(DisplayMaterial material, DisplayMaterial custom)
+        {
+            if (custom == null)
+                return material;
+
+            Color pColour = GH.Instances.ActiveCanvas.Document.PreviewColour;
+            Color ghColour = material.Diffuse;
+            if (ghColour.R == pColour.R & // If the color sent by PreviewArgs is the default object PreviewColour
+                ghColour.G == pColour.G &
+                ghColour.B == pColour.B) // Excluding Alpha channel from comparison
+            {
+                return custom;
+            }
+            else
+            {
+                return material;
+            }
+        }
+
+        /***************************************************/
     }
 }
 

--- a/Grasshopper_UI/Render/RenderRhinoWires.cs
+++ b/Grasshopper_UI/Render/RenderRhinoWires.cs
@@ -251,6 +251,12 @@ namespace BH.UI.Grasshopper
             pipeline.DrawBox(bbBox, bhColour, thickness);
         }
 
+        /***************************************************/
+
+        public static void RenderRhinoWires(RHG.Box box, Rhino.Display.DisplayPipeline pipeline, Color bhColour, int thickness)
+        {
+            pipeline.DrawBox(box, bhColour, thickness);
+        }
 
         /***************************************************/
         /**** Public Methods  - Representations         ****/
@@ -261,7 +267,6 @@ namespace BH.UI.Grasshopper
 
             pipeline.Draw3dText(text3D, bhColour, text3D.TextPlane); 
         }
-
 
         /***************************************************/
     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #655

<!-- Add short description of what has been fixed -->

Changes the way geometry is rendered from rendering Surface geometry via the specific render method accepting Breps, to instead extract PreviewMeshes that are cached at first preview and then reused to preview.

Also storing preview material rather than only preview colour, as creating those for each frame also slows things down.

This will increase the demand on RAM slightly, but from initial testing with a quite significant amount of obejcts this has not yet proven to be a massive problem.

If it is, we could have a look to instead remove the cached BHoM geometry and Rhino geometry, for them to be extracted on the fly instead, and directly turned to the preview meshes.

### Test files
<!-- Link to test files to validate the proposed changes -->

Two testfiles in the folder, first testing that all of our surface types are still visible, second testing the speed. The speed testfile is able to relatively decently handle 100 000 panels with the code on this PR, while it can not handle a fraction of that on main.

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Grasshopper_Toolkit/%23656-CachingOfPreviewMeshesToImprovePerformance?csf=1&web=1&e=OV1WJr


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->