### PR TITLE
Improve BHoM loading time in Grasshopper

### DIFF
--- a/Grasshopper_Engine/Grasshopper_Engine.csproj
+++ b/Grasshopper_Engine/Grasshopper_Engine.csproj
@@ -20,62 +20,62 @@
     <Reference Include="BHoM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramData)\BHoM\Assemblies\BHoM.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="BHoM_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramData)\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="BHoM_UI">
       <HintPath>$(ProgramData)\BHoM\Assemblies\BHoM_UI.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Data_Engine">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Data_Engine.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Dimensional_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Dimensional_oM.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Geometry_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramData)\BHoM\Assemblies\Geometry_Engine.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Geometry_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Geometry_oM.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Graphics_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Graphics_oM.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Programming_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Programming_oM.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Reflection_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramData)\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Rhinoceros_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramData)\BHoM\Assemblies\Rhinoceros_Engine.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Serialiser_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramData)\BHoM\Assemblies\Serialiser_Engine.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -88,12 +88,12 @@
     <Reference Include="System.Xml" />
     <Reference Include="UI_Engine">
       <HintPath>$(ProgramData)\BHoM\Assemblies\UI_Engine.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="UI_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\UI_oM.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
   </ItemGroup>

--- a/Grasshopper_UI/Grasshopper_UI.csproj
+++ b/Grasshopper_UI/Grasshopper_UI.csproj
@@ -25,89 +25,89 @@
   <ItemGroup>
     <Reference Include="BHoM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\BHoM.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="BHoM_Adapter">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramData)\BHoM\Assemblies\BHoM_Adapter.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="BHoM_Engine">
       <HintPath>$(ProgramData)\BHoM\Assemblies\BHoM_Engine.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="BHoM_UI">
       <HintPath>$(ProgramData)\BHoM\Assemblies\BHoM_UI.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="BHoM_Windows_UI">
       <HintPath>$(ProgramData)\BHoM\Assemblies\BHoM_Windows_UI.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Data_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramData)\BHoM\Assemblies\Data_Engine.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Data_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramData)\BHoM\Assemblies\Data_oM.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Dimensional_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Dimensional_oM.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Geometry_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramData)\BHoM\Assemblies\Geometry_Engine.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Geometry_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramData)\BHoM\Assemblies\Geometry_oM.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Graphics_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Graphics_oM.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Library_Engine">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Library_Engine.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Planning_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Planning_oM.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="Programming_Engine">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Programming_Engine.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Programming_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Programming_oM.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Reflection_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramData)\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Rhinoceros_Engine">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Rhinoceros_Engine.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Script, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -118,7 +118,7 @@
     <Reference Include="Serialiser_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramData)\BHoM\Assemblies\Serialiser_Engine.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -127,16 +127,16 @@
     <Reference Include="UI_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramData)\BHoM\Assemblies\UI_Engine.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="UI_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ProgramData)\BHoM\Assemblies\UI_oM.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy &quot;$(TargetDir)$(TargetName).dll&quot; &quot;$(ProgramData)\BHoM\Assemblies\$(TargetName).gha&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)Script.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;echo $(ProgramData)\BHoM\Assemblies\$(TargetName).gha &gt; &quot;$(AppData)\Grasshopper\Libraries\$(TargetName).ghlink&quot;&#xD;&#xA;" />
+    <Exec Command="if not exist &quot;$(ProgramData)\BHoM\GrasshopperPlugin\&quot; mkdir &quot;$(ProgramData)\BHoM\GrasshopperPlugin&quot;&#xD;&#xA;xcopy &quot;$(TargetDir)*.dll&quot;  &quot;$(ProgramData)\BHoM\GrasshopperPlugin\&quot; /Y&#xD;&#xA;ren &quot;$(ProgramData)\BHoM\GrasshopperPlugin\$(TargetName).dll&quot; &quot;$(TargetName).gha&quot;&#xD;&#xA;echo $(ProgramData)\BHoM\GrasshopperPlugin\$(TargetName).gha &gt; &quot;$(AppData)\Grasshopper\Libraries\$(TargetName).ghlink&quot;&#xD;&#xA;" />
   </Target>
  
 </Project>

--- a/Grasshopper_UI/Grasshopper_UI.csproj
+++ b/Grasshopper_UI/Grasshopper_UI.csproj
@@ -136,7 +136,7 @@
     </Reference>
   </ItemGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="if not exist &quot;$(ProgramData)\BHoM\GrasshopperPlugin\&quot; mkdir &quot;$(ProgramData)\BHoM\GrasshopperPlugin&quot;&#xD;&#xA;xcopy &quot;$(TargetDir)*.dll&quot;  &quot;$(ProgramData)\BHoM\GrasshopperPlugin\&quot; /Y&#xD;&#xA;ren &quot;$(ProgramData)\BHoM\GrasshopperPlugin\$(TargetName).dll&quot; &quot;$(TargetName).gha&quot;&#xD;&#xA;echo $(ProgramData)\BHoM\GrasshopperPlugin\$(TargetName).gha &gt; &quot;$(AppData)\Grasshopper\Libraries\$(TargetName).ghlink&quot;&#xD;&#xA;" />
+    <Exec Command="if not exist &quot;$(ProgramData)\BHoM\GrasshopperPlugin\&quot; mkdir &quot;$(ProgramData)\BHoM\GrasshopperPlugin&quot;&#xD;&#xA;xcopy &quot;$(TargetDir)*.dll&quot;  &quot;$(ProgramData)\BHoM\GrasshopperPlugin\&quot; /Y&#xD;&#xA;if exist &quot;$(ProgramData)\BHoM\GrasshopperPlugin\$(TargetName).gha&quot; del &quot;$(ProgramData)\BHoM\GrasshopperPlugin\$(TargetName).gha&quot;&#xD;&#xA;ren &quot;$(ProgramData)\BHoM\GrasshopperPlugin\$(TargetName).dll&quot; &quot;$(TargetName).gha&quot;&#xD;&#xA;echo $(ProgramData)\BHoM\GrasshopperPlugin\$(TargetName).gha &gt; &quot;$(AppData)\Grasshopper\Libraries\$(TargetName).ghlink&quot;&#xD;&#xA;" />
   </Target>
  
 </Project>

--- a/Grasshopper_oM/Grasshopper_oM.csproj
+++ b/Grasshopper_oM/Grasshopper_oM.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <Reference Include="BHoM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\BHoM.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Relates to
https://github.com/BHoM/BHoM_UI/pull/531

 ### NOTE: Depends on 
https://github.com/BHoM/BHoM_Installer/pull/253
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #732 

This PR addresses https://github.com/BHoM/BHoM_UI/issues/521 alongside the BHoM_UI PR linked above.

This specifically addresses the slow loading time of BHoM_UI in Grasshopper despite our lazy loading strategy for the assemblies.

This was caused by a full scan of our assembly folder as soon as Grasshopper was trying to load our UI. With over 600 dlls, this was taking over a minute with no benefit to our strategy.

Based on a test on my machines, loading the BHoM_UI on a fresh machine reboot gives us this improvement on the folder scanning part of the UI loading:
 - Without this PR: **68s** 
 - With this PR: **3.7s** 

The solution implemented here is to move the dlls directly required by our Grasshopper plugin to a new `C:\ProgramData\BHoM\GrasshopperPlugin" folder.

**Note**: This PR is enough for local testing but we will need to also fix both installers before this PR can be merged.
**Note 2**: This PR can be merged after the BHoM_UI PR is merged as it solves a separate problem.

### Test files

Continue your testing from https://github.com/BHoM/BHoM_UI/pull/531 but with this code compiled. 