### PR TITLE
Make sure the wire menu only shows when a wire is dragged

### DIFF
--- a/Grasshopper_UI/Global/GlobalSearch.cs
+++ b/Grasshopper_UI/Global/GlobalSearch.cs
@@ -164,18 +164,25 @@ namespace BH.UI.Grasshopper.Global
             FieldInfo targetField = typeof(GH_WireInteraction).GetField("m_target", BindingFlags.NonPublic | BindingFlags.Instance);
             if (targetField != null && targetField.GetValue(m_LastWire.Wire) != null)
             {
-                m_LastWire = null;
                 Debug.WriteLine(DateTime.Now.ToString("HH:mm:ss") + "- Wire info cleared.");
             }
-            else
+            else if (m_LastWire.Wire.ControlPointDown != null)
             {
-                GlobalSearch.Open(canvas.FindForm(), new SearchConfig
+                // Only show the menu if the wire was dragged far enought from the connector (arbitrary distance of 20 pixels used as threshold)
+                double distance = Math.Sqrt(Math.Pow(e.Location.X - m_LastWire.Wire.ControlPointDown.X, 2) + Math.Pow(e.Location.Y - m_LastWire.Wire.ControlPointDown.Y, 2));
+                if (distance > 20)
                 {
-                    TypeConstraint = m_LastWire.SourceType,
-                    IsReturnType = m_LastWire.IsInput,
-                    Tags = m_LastWire.Tags
-                });
-            } 
+                    GlobalSearch.Open(canvas.FindForm(), new SearchConfig
+                    {
+                        TypeConstraint = m_LastWire.SourceType,
+                        IsReturnType = m_LastWire.IsInput,
+                        Tags = m_LastWire.Tags
+                    });
+                }
+            }
+
+            // Clear the last wire
+            m_LastWire = null;
         }
 
         /*******************************************/

--- a/Grasshopper_UI/Global/GlobalSearch.cs
+++ b/Grasshopper_UI/Global/GlobalSearch.cs
@@ -121,6 +121,10 @@ namespace BH.UI.Grasshopper.Global
                     return;
                 IGH_Param sourceParam = sourceField.GetValue(wire) as IGH_Param;
 
+                // Only work with BHoM components
+                if (!(sourceParam is IBHoMParam || sourceParam is CallerValueList))
+                    return;
+
                 // Get the source Type
                 Type sourceType = GetSourceType(sourceParam);
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #743 

As described in the issue, the BHoM wire menu was also showing up with a simple click on a component connector, without the need to actually drag a wire. This was preventing other GH functionalities like the creation of relays by double-clicking on a connector.  

This PR fixes that by a travel distance threshold before the menu is triggered on mouse-up events.

This PR also limits the wire menu to BHoM components. The menu is irrelevant for non-BHoM components since it will not be able to filter much and can potentially be annoying when people are not using BHoM components, even with the bug fixed. See this issue for more details: https://github.com/BHoM/Grasshopper_UI/issues/593

### Test files
No need for a test file here, 
 - Just create any component and interact with its connectors in any way you can think of and check that the menu only pops up when it makes sense. 
- Create various types of BHoM components (param components, dropdown components, ...) and make sure the wire menu works on them. Then create non-BHoM components and make sure the wire menu does show up on them.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->