### PR TITLE
Fix dictionary input set to null after component copy

### DIFF
--- a/Grasshopper_UI/Goos/GH_Dictionary.cs
+++ b/Grasshopper_UI/Goos/GH_Dictionary.cs
@@ -20,13 +20,17 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Serialiser;
+using BH.oM.Base;
+using GH_IO;
+using GH_IO.Serialization;
 using Grasshopper.Kernel.Types;
 using System.Collections;
 using BH.Engine.Reflection;
 
 namespace BH.UI.Grasshopper.Goos
 {
-    public class GH_Dictionary : GH_BHoMGoo<IDictionary>
+    public class GH_Dictionary : GH_BHoMGoo<IDictionary>, GH_ISerializable
     {
         /*******************************************/
         /**** Properties                        ****/
@@ -57,6 +61,34 @@ namespace BH.UI.Grasshopper.Goos
         public override IGH_Goo Duplicate()
         {
             return new GH_Dictionary { Value = Value };
+        }
+
+        /*******************************************/
+
+        public override bool Write(GH_IWriter writer)
+        {
+            if (Value != null)
+                writer.SetString("Json", Value.ToJson());
+            return true;
+        }
+
+        /*******************************************/
+
+        public override bool Read(GH_IReader reader)
+        {
+            string json = "";
+            reader.TryGetString("Json", ref json);
+
+            if (json != null && json.Length > 0)
+            {
+                object fromJson = BH.Engine.Serialiser.Convert.FromJson(json);
+                if (fromJson is IDictionary dict)
+                    Value = dict;
+                else if (fromJson is CustomObject co)
+                    Value = co.CustomData;
+            }
+
+            return true;
         }
 
         /*******************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF 
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #746 

Default value for dictionary inputs were not set correctly when a component was copied. 
The same was happening if the dictionary input had been internalized. When the component was copied, the internalised input would be lost.


### Test files
Make sure copied components maintain their dictionary input both for default value and internalised value. 
Here's a script that can help with that:
[DictionariesSetToNullWhenCopied.zip](https://github.com/user-attachments/files/27319196/DictionariesSetToNullWhenCopied.zip)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->